### PR TITLE
docs(library-solidity): specify operator semantics and document the 0.15 surface

### DIFF
--- a/docs/solidity-guides/SUMMARY.md
+++ b/docs/solidity-guides/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Supported types](types.md)
 - [Handles](handles.md)
 - [Operations on encrypted types](operations/README.md)
+  - [Operator semantics](operations/semantics.md)
   - [Casting and trivial encryption](operations/casting.md)
   - [Generate random numbers](operations/random.md)
 - [Encrypted inputs](inputs.md)
@@ -32,6 +33,8 @@
   - [Dealing with branches and conditions](logics/loop.md)
   - [Error handling](logics/error_handling.md)
 - [Public Decryption](decryption/oracle.md)
+  - [Verifying public decryptions](decryption/verification.md)
+- [Confidential bridge](bridge.md)
 - [FHEVM API reference](functions.md)
 
 ## Development Guide
@@ -50,3 +53,4 @@
   - [forge-fhevm API reference](foundry/api.md)
 - [HCU](hcu.md)
 - [How to Transform Your Smart Contract into a FHEVM Smart Contract?](transform_smart_contract_with_fhevm.md)
+- [Migrating to v0.15](migrating-to-0.15.md)

--- a/docs/solidity-guides/bridge.md
+++ b/docs/solidity-guides/bridge.md
@@ -6,7 +6,7 @@ Bridging a handle does **not** move or re-encrypt the ciphertext. The coprocesso
 
 ## When to use it
 
-- A confidential token that lives on Ethereum and Polygon and lets holders move balances between the two.
+- A confidential token deployed on two host chains that lets holders move balances between the two.
 - A contract that computes an encrypted result on one chain and needs another chain to consume it (a shared randomness, an encrypted price, a vote outcome).
 - Any cross-chain flow where the values must stay encrypted end to end.
 
@@ -142,14 +142,7 @@ It is invoked by the local `ConfidentialBridge` in a dedicated `lzCompose` trans
 
 ## Endpoint ids
 
-| Host chain       | Chain id | LayerZero eid |
-| ---------------- | -------- | ------------- |
-| Ethereum mainnet | 1        | 30101         |
-| Polygon          | 137      | 30109         |
-| Sepolia          | 11155111 | 40161         |
-| Polygon Amoy     | 80002    | 40267         |
-
-The bridge is only wired between chains that belong to the same protocol environment (mainnet with mainnet, testnet with testnet).
+Destinations are identified by their LayerZero endpoint id (`eid`), not by chain id. The bridge is only wired between host chains that belong to the same protocol environment (mainnet with mainnet, testnet with testnet); `setPeer` reverts with `UnsupportedEid` for any other destination. Refer to the LayerZero deployments list for the `eid` of each host chain.
 
 ## Security notes
 

--- a/docs/solidity-guides/bridge.md
+++ b/docs/solidity-guides/bridge.md
@@ -1,0 +1,158 @@
+# Confidential bridge
+
+The confidential bridge lets a contract move encrypted handles from one host chain to another. It is built on LayerZero messaging and operated by the Zama protocol: a `ConfidentialBridge` contract is deployed on every supported host chain, and the `FHE` library exposes the functions needed to talk to it.
+
+Bridging a handle does **not** move or re-encrypt the ciphertext. The coprocessors already hold the ciphertext for both chains; the bridge tells the destination chain which handle corresponds to which source handle, and grants the destination app the right to use it. The plaintext is never revealed.
+
+## When to use it
+
+- A confidential token that lives on Ethereum and Polygon and lets holders move balances between the two.
+- A contract that computes an encrypted result on one chain and needs another chain to consume it (a shared randomness, an encrypted price, a vote outcome).
+- Any cross-chain flow where the values must stay encrypted end to end.
+
+## Two ways to integrate
+
+| Approach                                        | Use it when                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Inherit `ConfidentialOApp` (recommended)        | You control both ends and want peer management, sender helpers and a secured receiver. |
+| Call `FHE.sendLZConfidentialBridge` directly    | You only send, or you need full control over the LayerZero parameters.                    |
+
+Both live in `@fhevm/solidity`. The abstract contracts are under `lib/bridge/`.
+
+## Approach 1: `ConfidentialOApp`
+
+`ConfidentialOApp` combines `ConfidentialOAppSender` and `ConfidentialOAppReceiver` on top of a shared peer registry (`ConfidentialOAppCore`, which is `Ownable`). A **peer** is the trusted instance of your app on another chain, identified by its LayerZero endpoint id (`eid`). Peers are `bytes32` so that non-EVM chains fit; an EVM address is left-padded.
+
+```solidity
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHE, euint64} from "@fhevm/solidity/lib/FHE.sol";
+import {ConfidentialOApp} from "@fhevm/solidity/lib/bridge/ConfidentialOApp.sol";
+import {ZamaEthereumConfig} from "@fhevm/solidity/config/ZamaConfig.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract CrossChainCounter is ZamaEthereumConfig, ConfidentialOApp {
+  euint64 private _total;
+
+  // ConfidentialOAppCore is Ownable: the owner manages peers through setPeer.
+  constructor(address owner) Ownable(owner) {}
+
+  /// Send the current total to the peer on `dstEid`. Caller pays the LayerZero fee.
+  function push(uint32 dstEid, uint64 lzComposeGas) external payable {
+    // The bridge only accepts handles this contract is allowed to use.
+    FHE.allowThis(_total);
+    _sendHandleToPeer(dstEid, abi.encode(block.number), _total, lzComposeGas);
+  }
+
+  /// Quote the native fee the caller must attach to `push`. Only the payload size matters.
+  function quotePush(uint32 dstEid, uint64 lzComposeGas) external view returns (uint256) {
+    return _quoteSendHandleToPeer(dstEid, abi.encode(block.number), lzComposeGas);
+  }
+
+  /// Called by the local bridge after it verified the caller and the peer.
+  function _onReceiveHandles(
+    uint32, /* srcEid */
+    bytes32, /* srcApp */
+    bytes calldata, /* payload */
+    bytes32[] calldata, /* srcHandleList */
+    bytes32[] calldata dstHandleList,
+    bytes32 /* guid */
+  ) internal override {
+    euint64 incoming = euint64.wrap(dstHandleList[0]);
+    _total = FHE.add(_total, incoming);
+    FHE.allowThis(_total);
+  }
+}
+```
+
+Deployment steps:
+
+1. Deploy the contract on each chain.
+2. On each chain, call `setPeer(remoteEid, bytes32(uint256(uint160(remoteAddress))))`. `setPeer` reverts with `ConfidentialBridgeNotDeployed` if the bridge is absent on the current chain, and with `UnsupportedEid` if the bridge is not wired to that destination.
+3. Fund the sending contract, or make the entry point `payable`, so the LayerZero native fee can be forwarded.
+
+What the base contracts do for you:
+
+- `_sendHandleToPeer` / `_sendHandlesToPeer` (typed overloads for every encrypted type, plus a raw `bytes32[]` form for up to 32 handles) look up the peer, forward `msg.value` as the fee, and return the LayerZero `guid` and `nonce`.
+- `_quoteSendHandleToPeer` / `_quoteSendHandlesToPeer` return the native fee to attach.
+- `onConfidentialBridgeReceived` (from `IDstApp`) checks that `msg.sender` is the local `ConfidentialBridge` and that `(srcEid, srcApp)` is a registered peer, then calls your `_onReceiveHandles`. Skipping either check would let anyone deliver forged handles, so do not override the entry point itself.
+
+## Approach 2: the `FHE` library functions
+
+```solidity
+function getLZConfidentialBridgeAddress() internal view returns (address)
+
+function quoteLZConfidentialBridge(
+    uint32 dstEid,
+    address srcApp,
+    bytes32 dstApp,
+    bytes memory payload,
+    bytes32[] memory handleList,
+    uint64 lzComposeGas
+) internal view returns (uint256 nativeFee)
+
+function sendLZConfidentialBridge(
+    uint32 dstEid,
+    bytes32 dstApp,
+    bytes memory payload,
+    bytes32[] memory handleList,
+    uint64 lzComposeGas,
+    uint256 nativeFee
+) internal returns (bytes32 guid, uint64 nonce)
+```
+
+- `getLZConfidentialBridgeAddress` resolves the bridge from the ACL and reverts with `ConfidentialBridgeNotDeployed` when the chain has none.
+- `quoteLZConfidentialBridge` prices a message. Only the **sizes** of `payload` and `handleList` matter for the quote, not their contents, so you can pass zero-filled placeholders of the right length.
+- `sendLZConfidentialBridge` sends. `nativeFee` is forwarded as `msg.value` and must **exactly** equal the quote for the same parameters; the bridge reverts with `MsgValueMustEqualQuotedFee` on any difference, including overpayment. Quote immediately before sending, and retry with a fresh quote if the send reverts.
+
+Constraints enforced by the bridge:
+
+| Rule                                   | Failure                                           |
+| -------------------------------------- | ------------------------------------------------- |
+| `handleList` non-empty                 | `EmptyHandleList()`                               |
+| `handleList` has at most 32 entries    | revert (`MAX_HANDLES`)                            |
+| Sender is allowed on every handle      | `HandleNotAllowed(handle, srcApp)`                |
+| `dstEid` is wired on the bridge        | `UnknownDstEid(dstEid)`                           |
+| `lzComposeGas > 0`                     | revert                                            |
+| `nativeFee == quote`                   | `MsgValueMustEqualQuotedFee(msg.value, required)` |
+| Bridge deployed on this chain          | `ConfidentialBridgeNotDeployed()`                 |
+
+### Implementing the receiving side by hand
+
+If you do not inherit `ConfidentialOAppReceiver`, your destination contract must implement `IDstApp`:
+
+```solidity
+function onConfidentialBridgeReceived(
+    uint32 srcEid,
+    bytes32 srcApp,
+    bytes calldata payload,
+    bytes32[] calldata srcHandleList,
+    bytes32[] calldata dstHandleList,
+    bytes32 guid
+) external;
+```
+
+It is invoked by the local `ConfidentialBridge` in a dedicated `lzCompose` transaction, after the bridge has granted your contract **transient** ACL allowance on every entry of `dstHandleList`. You must verify that `msg.sender` is the bridge and that `(srcEid, srcApp)` is trusted. Treat `srcHandleList` as opaque: those are source-chain handles and cannot be used locally. Wrap `dstHandleList[i]` to the type you expect (`euint64.wrap(...)`) and persist the allowance with `FHE.allowThis` if you store the value.
+
+## Gas and delivery
+
+- `lzComposeGas` is the gas budget for your `onConfidentialBridgeReceived` on the destination chain. Size it for the work your callback does, including any `FHE.*` calls. If it is too low, LayerZero does not deliver automatically; the message sits in the `lzCompose` queue until someone calls `lzCompose` on the destination endpoint with the same `guid`.
+- The quoted fee depends on the destination, the payload size, the number of handles and `lzComposeGas`. It moves with gas prices, hence the exact-match rule.
+
+## Endpoint ids
+
+| Host chain       | Chain id | LayerZero eid |
+| ---------------- | -------- | ------------- |
+| Ethereum mainnet | 1        | 30101         |
+| Polygon          | 137      | 30109         |
+| Sepolia          | 11155111 | 40161         |
+| Polygon Amoy     | 80002    | 40267         |
+
+The bridge is only wired between chains that belong to the same protocol environment (mainnet with mainnet, testnet with testnet).
+
+## Security notes
+
+- Bridged handles keep their ACL semantics. The destination app receives a transient allowance only; nothing is granted to end users until the app calls `FHE.allow`.
+- A destination handle is a new handle. Do not assume any relation between `srcHandleList[i]` and `dstHandleList[i]` beyond "same plaintext" (see [Handles](handles.md)).
+- `setPeer` is owner-only. Losing the owner key means losing the ability to rotate peers; plan governance accordingly.

--- a/docs/solidity-guides/configure.md
+++ b/docs/solidity-guides/configure.md
@@ -11,37 +11,19 @@ This library and its associated contracts provide a standardized way to configur
 ## Key components configured automatically
 
 1. **FHE library**: Sets up encryption parameters and cryptographic keys.
-2. **Network-specific settings**: Adapts to local testing, testnets (Sepolia, Polygon Amoy) or mainnet deployments (Ethereum, Polygon).
+2. **Network-specific settings**: Adapts to local testing, testnets (Sepolia for example), or mainnet deployment.
 
 By inheriting these configuration contracts, you ensure seamless initialization and functionality across environments.
 
 ## ZamaConfig.sol
 
-The `ZamaConfig` library exposes functions to retrieve FHEVM configuration structs and contract addresses for every network where the Zama protocol is deployed:
+The `ZamaConfig` library exposes functions to retrieve FHEVM configuration structs and contract addresses for supported networks: Ethereum mainnet (chain id `1`), Sepolia testnet (`11155111`) and the local Hardhat/Anvil network (`31337`). `getCoprocessorConfig()` picks the right entry from `block.chainid` and reverts with `ZamaProtocolUnsupported` on any other chain.
 
-| Network          | Chain id   | Environment | Selector                        |
-| ---------------- | ---------- | ----------- | ------------------------------- |
-| Ethereum mainnet | `1`        | mainnet     | `getEthereumCoprocessorConfig`  |
-| Polygon          | `137`      | mainnet     | `getPolygonCoprocessorConfig`   |
-| Sepolia          | `11155111` | testnet     | `getEthereumCoprocessorConfig`  |
-| Polygon Amoy     | `80002`    | testnet     | `getPolygonCoprocessorConfig`   |
-| Hardhat / Anvil  | `31337`    | local       | any selector                    |
+Under the hood, this library encapsulates the network-specific addresses of Zama's FHEVM infrastructure into a single struct (`CoprocessorConfig`). It also exposes `getConfidentialProtocolId()`: `1` on mainnet, `10001` on testnet, `type(uint256).max` locally.
 
-`getCoprocessorConfig()` picks the right entry from `block.chainid` for all of them and reverts with `ZamaProtocolUnsupported` on any other chain. Under the hood, the library encapsulates the network-specific addresses of Zama's FHEVM infrastructure into a single struct (`CoprocessorConfig`).
+## ZamaEthereumConfig
 
-The library also exposes `getConfidentialProtocolId()`: `1` on mainnet chains (Ethereum, Polygon), `10001` on testnet chains (Sepolia, Amoy), `type(uint256).max` locally. Ethereum and Polygon are different host chains talking to the **same** gateway and KMS, so a mainnet contract deployed on both chains shares one protocol environment.
-
-## Configuration contracts
-
-Three abstract contracts wrap the library so that a user contract only has to inherit from one of them. Their constructor calls `FHE.setCoprocessor` with the addresses for the chain the contract is being deployed on, which removes manual address management and the risk of misconfiguration. Each also exposes `confidentialProtocolId()`.
-
-| Contract                | Chains accepted at deployment                    | Use it when                                          |
-| ----------------------- | ------------------------------------------------ | ---------------------------------------------------- |
-| `ZamaEthereumConfig`    | Ethereum mainnet, Sepolia, local                 | The contract only ever lives on Ethereum.            |
-| `ZamaPolygonConfig`     | Polygon, Polygon Amoy, local                     | The contract only ever lives on Polygon.             |
-| `ZamaMultiChainConfig`  | all of the above                                 | One bytecode deployed on several host chains.        |
-
-Deploying on a chain the selected contract does not accept reverts in the constructor with `ZamaProtocolUnsupported`.
+The `ZamaEthereumConfig` contract is designed to be inherited by a user contract. Its constructor calls `FHE.setCoprocessor` with the addresses for the chain the contract is being deployed on, which removes manual address management and the risk of misconfiguration. It also exposes `confidentialProtocolId()`. Deploying on an unsupported chain reverts in the constructor with `ZamaProtocolUnsupported`.
 
 **Example**
 
@@ -57,20 +39,6 @@ contract MyERC20 is ZamaEthereumConfig {
   }
 }
 ```
-
-The same contract, deployable on Ethereum and Polygon from a single artifact:
-
-```solidity
-import { ZamaMultiChainConfig } from "@fhevm/solidity/config/ZamaConfig.sol";
-
-contract MyERC20 is ZamaMultiChainConfig {
-  constructor() {}
-}
-```
-
-{% hint style="info" %}
-Handles are chain-specific. A contract deployed on both chains holds independent encrypted state on each; to move a value across chains, use the [confidential bridge](bridge.md).
-{% endhint %}
 
 ## Using `isInitialized`
 
@@ -95,4 +63,4 @@ require(FHE.isInitialized(counter), "Counter not initialized!");
 
 ## Summary
 
-By leveraging a prebuilt configuration contract like `ZamaEthereumConfig`, `ZamaPolygonConfig` or `ZamaMultiChainConfig` from `ZamaConfig.sol`, you can efficiently set up your smart contract for encrypted computations. These tools abstract the complexity of cryptographic initialization, allowing you to focus on building secure, confidential smart contracts.
+By leveraging a prebuilt configuration contract like `ZamaEthereumConfig` from `ZamaConfig.sol`, you can efficiently set up your smart contract for encrypted computations. These tools abstract the complexity of cryptographic initialization, allowing you to focus on building secure, confidential smart contracts.

--- a/docs/solidity-guides/configure.md
+++ b/docs/solidity-guides/configure.md
@@ -11,19 +11,37 @@ This library and its associated contracts provide a standardized way to configur
 ## Key components configured automatically
 
 1. **FHE library**: Sets up encryption parameters and cryptographic keys.
-2. **Network-specific settings**: Adapts to local testing, testnets (Sepolia for example), or mainnet deployment.
+2. **Network-specific settings**: Adapts to local testing, testnets (Sepolia, Polygon Amoy) or mainnet deployments (Ethereum, Polygon).
 
 By inheriting these configuration contracts, you ensure seamless initialization and functionality across environments.
 
 ## ZamaConfig.sol
 
-The `ZamaConfig` library exposes functions to retrieve FHEVM configuration structs and contract addresses for supported networks: Ethereum mainnet, Sepolia testnet, and local Hardhat environments.
+The `ZamaConfig` library exposes functions to retrieve FHEVM configuration structs and contract addresses for every network where the Zama protocol is deployed:
 
-Under the hood, this library encapsulates the network-specific addresses of Zama's FHEVM infrastructure into a single struct (`CoprocessorConfig`).
+| Network          | Chain id   | Environment | Selector                        |
+| ---------------- | ---------- | ----------- | ------------------------------- |
+| Ethereum mainnet | `1`        | mainnet     | `getEthereumCoprocessorConfig`  |
+| Polygon          | `137`      | mainnet     | `getPolygonCoprocessorConfig`   |
+| Sepolia          | `11155111` | testnet     | `getEthereumCoprocessorConfig`  |
+| Polygon Amoy     | `80002`    | testnet     | `getPolygonCoprocessorConfig`   |
+| Hardhat / Anvil  | `31337`    | local       | any selector                    |
 
-## ZamaEthereumConfig
+`getCoprocessorConfig()` picks the right entry from `block.chainid` for all of them and reverts with `ZamaProtocolUnsupported` on any other chain. Under the hood, the library encapsulates the network-specific addresses of Zama's FHEVM infrastructure into a single struct (`CoprocessorConfig`).
 
-The `ZamaEthereumConfig` contract is designed to be inherited by a user contract. The constructor automatically sets up the FHEVM coprocessor using the configuration provided by the library for the respective network. When a contract inherits from `ZamaEthereumConfig`, the constructor calls `FHE.setCoprocessor` with the appropriate addresses. This ensures that the inheriting contract is automatically wired to the correct FHEVM contracts for the target network, abstracting away manual address management and reducing the risk of misconfiguration.
+The library also exposes `getConfidentialProtocolId()`: `1` on mainnet chains (Ethereum, Polygon), `10001` on testnet chains (Sepolia, Amoy), `type(uint256).max` locally. Ethereum and Polygon are different host chains talking to the **same** gateway and KMS, so a mainnet contract deployed on both chains shares one protocol environment.
+
+## Configuration contracts
+
+Three abstract contracts wrap the library so that a user contract only has to inherit from one of them. Their constructor calls `FHE.setCoprocessor` with the addresses for the chain the contract is being deployed on, which removes manual address management and the risk of misconfiguration. Each also exposes `confidentialProtocolId()`.
+
+| Contract                | Chains accepted at deployment                    | Use it when                                          |
+| ----------------------- | ------------------------------------------------ | ---------------------------------------------------- |
+| `ZamaEthereumConfig`    | Ethereum mainnet, Sepolia, local                 | The contract only ever lives on Ethereum.            |
+| `ZamaPolygonConfig`     | Polygon, Polygon Amoy, local                     | The contract only ever lives on Polygon.             |
+| `ZamaMultiChainConfig`  | all of the above                                 | One bytecode deployed on several host chains.        |
+
+Deploying on a chain the selected contract does not accept reverts in the constructor with `ZamaProtocolUnsupported`.
 
 **Example**
 
@@ -39,6 +57,20 @@ contract MyERC20 is ZamaEthereumConfig {
   }
 }
 ```
+
+The same contract, deployable on Ethereum and Polygon from a single artifact:
+
+```solidity
+import { ZamaMultiChainConfig } from "@fhevm/solidity/config/ZamaConfig.sol";
+
+contract MyERC20 is ZamaMultiChainConfig {
+  constructor() {}
+}
+```
+
+{% hint style="info" %}
+Handles are chain-specific. A contract deployed on both chains holds independent encrypted state on each; to move a value across chains, use the [confidential bridge](bridge.md).
+{% endhint %}
 
 ## Using `isInitialized`
 
@@ -63,4 +95,4 @@ require(FHE.isInitialized(counter), "Counter not initialized!");
 
 ## Summary
 
-By leveraging prebuilt a configuration contract like `ZamaEthereumConfig` in `ZamaConfig.sol`, you can efficiently set up your smart contract for encrypted computations. These tools abstract the complexity of cryptographic initialization, allowing you to focus on building secure, confidential smart contracts.
+By leveraging a prebuilt configuration contract like `ZamaEthereumConfig`, `ZamaPolygonConfig` or `ZamaMultiChainConfig` from `ZamaConfig.sol`, you can efficiently set up your smart contract for encrypted computations. These tools abstract the complexity of cryptographic initialization, allowing you to focus on building secure, confidential smart contracts.

--- a/docs/solidity-guides/contract_addresses.md
+++ b/docs/solidity-guides/contract_addresses.md
@@ -1,7 +1,7 @@
 # Contract Addresses
 
 {% hint style="info" %}
-You do not need to configure these addresses manually. Inheriting from `ZamaEthereumConfig`, `ZamaPolygonConfig` or `ZamaMultiChainConfig` automatically resolves the correct addresses based on the current `block.chainid`. Ethereum and Polygon share the same gateway contracts; Sepolia and Polygon Amoy share the testnet gateway.
+You do not need to configure these addresses manually. Inheriting from `ZamaEthereumConfig` automatically resolves the correct addresses based on the current `block.chainid`.
 {% endhint %}
  
 ## Mainnet
@@ -17,18 +17,7 @@ You do not need to configure these addresses manually. Inheriting from `ZamaEthe
 | HCU_LIMIT                  | 0x3b4da65e45Fda2CAa0285A735ab4361a44F171E2 |
 | PROTOCOL_CONFIG            | 0xD8236B57394f90726b26aB25D38CeAC776E1a7C4 |
 
-### Polygon
-
-| Contract                   | Address                                    |
-| -------------------------- | ------------------------------------------ |
-| ACL                        | 0x6737F17e31cf26a1b62fb0362acC5a16CB156F49 |
-| FHEVM_EXECUTOR             | 0xAB0075E77fe06083f52bdf10e2ccDB3712483057 |
-| INPUT_VERIFIER             | 0xf40BD204B035522EaAc8E5afAdc55113Acac96ca |
-| KMS_VERIFIER               | 0x14e609595474874Dd6b6128376E336EfADfdBE37 |
-| HCU_LIMIT                  | 0x226cf23556E59e3284c3c7705868478746D338af |
-| PROTOCOL_CONFIG            | 0x17f62Ab3A1Ea519703cD597410147A30Fa1a7f1e |
-
-### Gateway (shared by Ethereum and Polygon)
+### Gateway
 
 | Contract                   | Address                                    |
 | -------------------------- | ------------------------------------------ |
@@ -53,18 +42,7 @@ You do not need to configure these addresses manually. Inheriting from `ZamaEthe
 | HCU_LIMIT                  | 0xa10998783c8CF88D886Bc30307e631D6686F0A22 |
 | PROTOCOL_CONFIG            | 0x51f9AFBc89Ea792e1a21a12AB802ab58D4dbee83 |
 
-### Polygon Amoy
-
-| Contract                   | Address                                    |
-| -------------------------- | ------------------------------------------ |
-| ACL_HOST                   | 0xD99Cb9Fc3c42c87f2A4A12e8Fd60318d6bDdf985 |
-| FHEVM_EXECUTOR             | 0x89420269f61e4db00545cd99da0aEcA7fF0912f9 |
-| INPUT_VERIFIER             | 0x6e5A7D8b0c645467Cba7e62D6624917085118631 |
-| KMS_VERIFIER               | 0xCD1D89E311bce4C8DEa9a0857a0c9A4E153D4041 |
-| HCU_LIMIT                  | 0x462f1920A9a7b5Aa74A36c3f49E38C34392B0546 |
-| PROTOCOL_CONFIG            | 0x4CcF009Aba90D04f52b31fc7aDdE240578aFe10F |
-
-### Gateway (shared by Sepolia and Polygon Amoy)
+### Gateway
 
 | Contract                   | Address                                    |
 | -------------------------- | ------------------------------------------ |

--- a/docs/solidity-guides/contract_addresses.md
+++ b/docs/solidity-guides/contract_addresses.md
@@ -1,7 +1,7 @@
 # Contract Addresses
 
 {% hint style="info" %}
-You do not need to configure these addresses manually. Inheriting from `ZamaEthereumConfig` automatically resolves the correct addresses based on the current `block.chainid`.
+You do not need to configure these addresses manually. Inheriting from `ZamaEthereumConfig`, `ZamaPolygonConfig` or `ZamaMultiChainConfig` automatically resolves the correct addresses based on the current `block.chainid`. Ethereum and Polygon share the same gateway contracts; Sepolia and Polygon Amoy share the testnet gateway.
 {% endhint %}
  
 ## Mainnet
@@ -15,9 +15,20 @@ You do not need to configure these addresses manually. Inheriting from `ZamaEthe
 | INPUT_VERIFIER             | 0xCe0FC2e05CFff1B719EFF7169f7D80Af770c8EA2 |
 | KMS_VERIFIER               | 0x77627828a55156b04Ac0DC0eb30467f1a552BB03 |
 | HCU_LIMIT                  | 0x3b4da65e45Fda2CAa0285A735ab4361a44F171E2 |
+| PROTOCOL_CONFIG            | 0xD8236B57394f90726b26aB25D38CeAC776E1a7C4 |
 
+### Polygon
 
-### Gateway 
+| Contract                   | Address                                    |
+| -------------------------- | ------------------------------------------ |
+| ACL                        | 0x6737F17e31cf26a1b62fb0362acC5a16CB156F49 |
+| FHEVM_EXECUTOR             | 0xAB0075E77fe06083f52bdf10e2ccDB3712483057 |
+| INPUT_VERIFIER             | 0xf40BD204B035522EaAc8E5afAdc55113Acac96ca |
+| KMS_VERIFIER               | 0x14e609595474874Dd6b6128376E336EfADfdBE37 |
+| HCU_LIMIT                  | 0x226cf23556E59e3284c3c7705868478746D338af |
+| PROTOCOL_CONFIG            | 0x17f62Ab3A1Ea519703cD597410147A30Fa1a7f1e |
+
+### Gateway (shared by Ethereum and Polygon)
 
 | Contract                   | Address                                    |
 | -------------------------- | ------------------------------------------ |
@@ -40,8 +51,20 @@ You do not need to configure these addresses manually. Inheriting from `ZamaEthe
 | INPUT_VERIFIER             | 0xBBC1fFCdc7C316aAAd72E807D9b0272BE8F84DA0 |
 | KMS_VERIFIER               | 0xbE0E383937d564D7FF0BC3b46c51f0bF8d5C311A |
 | HCU_LIMIT                  | 0xa10998783c8CF88D886Bc30307e631D6686F0A22 |
+| PROTOCOL_CONFIG            | 0x51f9AFBc89Ea792e1a21a12AB802ab58D4dbee83 |
 
-### Gateway
+### Polygon Amoy
+
+| Contract                   | Address                                    |
+| -------------------------- | ------------------------------------------ |
+| ACL_HOST                   | 0xD99Cb9Fc3c42c87f2A4A12e8Fd60318d6bDdf985 |
+| FHEVM_EXECUTOR             | 0x89420269f61e4db00545cd99da0aEcA7fF0912f9 |
+| INPUT_VERIFIER             | 0x6e5A7D8b0c645467Cba7e62D6624917085118631 |
+| KMS_VERIFIER               | 0xCD1D89E311bce4C8DEa9a0857a0c9A4E153D4041 |
+| HCU_LIMIT                  | 0x462f1920A9a7b5Aa74A36c3f49E38C34392B0546 |
+| PROTOCOL_CONFIG            | 0x4CcF009Aba90D04f52b31fc7aDdE240578aFe10F |
+
+### Gateway (shared by Sepolia and Polygon Amoy)
 
 | Contract                   | Address                                    |
 | -------------------------- | ------------------------------------------ |

--- a/docs/solidity-guides/decryption/verification.md
+++ b/docs/solidity-guides/decryption/verification.md
@@ -1,0 +1,103 @@
+# Verifying public decryptions on-chain
+
+When a contract consumes the result of a public decryption, the only thing standing between it and a forged cleartext is the **decryption proof** produced by the KMS. This page explains what the proof contains, how `FHE.checkSignatures` validates it, what the KMS context is, and how to write a callback that cannot be replayed. For the end-to-end flow (mark, decrypt off-chain, submit), see [Public decryption](oracle.md).
+
+## What the KMS signs
+
+Each KMS node that participates in a public decryption signs an EIP-712 message over:
+
+- the ordered list of handles that were decrypted,
+- the ABI encoding of the corresponding cleartexts, in the same order,
+- an `extraData` blob that identifies the KMS **context** (the set of signers and threshold in force when the decryption happened).
+
+The `KMSVerifier` contract on the host chain recovers the signers, checks that they belong to the context, that no signer is counted twice, and that the count reaches the public decryption threshold of that context.
+
+## Decryption proof layout
+
+The `decryptionProof` bytes returned by the SDK are:
+
+```text
+[ numSigners (1 byte) ] [ 65-byte signature ] x numSigners [ extraData ]
+```
+
+`extraData` is version-tagged:
+
+| First byte      | Layout                                          | Meaning                                                     |
+| --------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| absent or `0x00` | any                                            | Verify against the **current** KMS context.                 |
+| `0x01`          | `[0x01][contextId (32 bytes)]`                  | Verify against the KMS context `contextId`.                 |
+| `0x02`          | `[0x01][contextId (32 bytes)][epochId (32 bytes)]` | Same, plus the key epoch inside that context.            |
+
+Any other version or a malformed length reverts with `UnsupportedExtraDataVersion` or `DeserializingExtraDataFail`. You never build this blob yourself: the SDK returns the proof exactly as the relayer assembled it, and you forward it unchanged.
+
+## KMS contexts and why they matter
+
+The set of KMS operators can change over time (a **context switch**, for example when operators are added or keys are resharded). A proof produced under context `N` stays verifiable after the protocol moves to context `N+1`, as long as context `N` has not been **destroyed** by governance. Once destroyed, its proofs no longer verify. Practical consequences:
+
+- Do not store a proof for later. Submit it in the same transaction, or shortly after, the off-chain decryption.
+- A contract that keeps decryption results must store the **cleartexts**, not the proof.
+- `FHE.getContextSignersAndThresholdFromExtraData(extraData)` exposes, for auditing or monitoring, the signer set and threshold a proof will be checked against.
+
+## The two verification functions
+
+```solidity
+function checkSignatures(
+    bytes32[] memory handlesList,
+    bytes memory abiEncodedCleartexts,
+    bytes memory decryptionProof
+) internal
+
+function isPublicDecryptionResultValid(
+    bytes32[] memory handlesList,
+    bytes memory abiEncodedCleartexts,
+    bytes memory decryptionProof
+) internal view returns (bool)
+```
+
+| | `checkSignatures` | `isPublicDecryptionResultValid` |
+| --- | --- | --- |
+| On invalid proof | reverts with `InvalidKMSSignatures` | returns `false` |
+| On malformed proof | reverts | reverts |
+| Emits `PublicDecryptionVerified(handlesList, abiEncodedCleartexts)` | yes | no |
+| Caches verification in transient storage (cheaper repeated checks) | yes | no |
+| Usable in `view` / `eth_call` | no | yes |
+
+Use `checkSignatures` in every state-changing callback. Use the `view` variant only for read-only checks such as off-chain simulation, and always `require` its return value if you do call it on-chain: forgetting the `require` silently accepts forged results.
+
+Both functions revert when the proof is empty or too short, when fewer valid signatures than the threshold are present, or when a signature was produced by an address that is not a registered signer of the resolved context. The `view` variant additionally returns `false` when the threshold is reached only by counting a signer twice.
+
+## Ordering
+
+The proof is bound to the **order** of `handlesList`. `abiEncodedCleartexts` must be `abi.encode(v0, v1, ...)` with the cleartexts in the same order and with the Solidity types matching the encrypted types (`bool` for `ebool`, `uint8` for `euint8`, `address` for `eaddress`, and so on). Use `FHE.toBytes32` to build the handle list from typed handles.
+
+## Replay protection is your job
+
+`checkSignatures` proves that *the KMS decrypted these handles to these values*. It does not prove that the caller is entitled to trigger the callback, nor that the callback has not run before. The same `(handles, cleartexts, proof)` triple verifies as many times as it is submitted. Every callback must therefore carry its own guard:
+
+```solidity
+bool private _revealed;
+
+function reveal(uint64 clearTotal, bytes calldata proof) external {
+  require(!_revealed, "already revealed");
+
+  bytes32[] memory handles = new bytes32[](1);
+  handles[0] = FHE.toBytes32(_encryptedTotal);
+  FHE.checkSignatures(handles, abi.encode(clearTotal), proof);
+
+  _revealed = true;
+  _settle(clearTotal);
+}
+```
+
+Typical guards: a boolean or a status enum per request, a mapping keyed by the handle, or a nonce included in the request. Checking that the handle passed in is the one your contract expects (as above, by reading it from storage rather than from calldata) also prevents a caller from submitting a valid proof for a different, unrelated handle.
+
+## Errors
+
+| Error                              | Meaning                                                              |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| `InvalidKMSSignatures()`           | `checkSignatures` failed verification.                               |
+| `EmptyDecryptionProof()`           | Proof has zero length.                                               |
+| `DeserializingDecryptionProofFail()` | Proof shorter than `1 + 65 * numSigners`.                          |
+| `DeserializingExtraDataFail()`     | `extraData` length does not match its version.                       |
+| `UnsupportedExtraDataVersion(v)`   | Unknown `extraData` version byte.                                    |
+| `KmsContextNotCreated(...)`, `InvalidKmsContext(...)` | The proof references a KMS context the `ProtocolConfig` does not know or no longer serves (destroyed). |

--- a/docs/solidity-guides/functions.md
+++ b/docs/solidity-guides/functions.md
@@ -62,28 +62,33 @@ The library ensures that all operations on encrypted data follow the constraints
 
 #### `asEuint`
 
-The `asEuint` functions serve three purposes:
+The `asEuint` functions serve two purposes:
 
-- verify ciphertext bytes and return a valid handle to the calling smart contract;
 - cast a `euintX` typed ciphertext to a `euintY` typed ciphertext, where `X != Y`;
 - trivially encrypt a plaintext value.
 
-The first case is used to process encrypted inputs, e.g. user-provided ciphertexts. Those are generally included in a transaction payload.
+In the first case, when `X > Y` the most significant bits are dropped (truncation); when `X < Y` the value is zero-extended.
 
-The second case is self-explanatory. When `X > Y`, the most significant bits are dropped. When `X < Y`, the ciphertext is padded to the left with trivial encryptions of `0`.
+The second case is used to "encrypt" a public value so that it can be used as a ciphertext. Note that what we call a trivial encryption is **not** secure in any sense. When trivially encrypting a plaintext value, this value is still visible on-chain. More information about trivial encryption can be found [here](https://www.zama.ai/post/tfhe-deep-dive-part-1).
 
-The third case is used to "encrypt" a public value so that it can be used as a ciphertext. Note that what we call a trivial encryption is **not** secure in any sense. When trivially encrypting a plaintext value, this value is still visible in the ciphertext bytes. More information about trivial encryption can be found [here](https://www.zama.ai/post/tfhe-deep-dive-part-1).
+Encrypted **inputs** provided by users (`externalEuintX` plus an input proof) are converted with `FHE.fromExternal`, see [Encrypted inputs](inputs.md).
 
 **Examples**
 
 ```solidity
-// first case
-function asEuint8(bytes memory ciphertext) internal view returns (euint8)
-// second case
-function asEuint16(euint8 ciphertext) internal view returns (euint16)
-// third case
-function asEuint16(uint16 value) internal view returns (euint16)
+// cast
+function asEuint16(euint8 value) internal returns (euint16)
+// trivial encryption
+function asEuint16(uint16 value) internal returns (euint16)
 ```
+
+#### `toExternal`
+
+```solidity
+function toExternal(T value) internal pure returns (externalT)
+```
+
+Re-wraps an on-chain encrypted value into its `external` counterpart (`euint64` to `externalEuint64`, and so on) so that it can be passed to a function typed for encrypted inputs, together with an empty input proof. It performs no verification and grants no access: the receiving contract must already be allowed on the handle. See [Re-exporting a handle](inputs.md#re-exporting-a-handle-with-fhetoexternal).
 
 #### &#x20;`asEbool`
 
@@ -141,6 +146,23 @@ function div(euint8 a, uint8 b) internal pure returns (euint8)
 function div(euint16 a, uint16 b) internal pure returns (euint16)
 function div(euint32 a, uint32 b) internal pure returns (euint32)
 ```
+
+#### Multiply then divide - `mulDiv`
+
+```solidity
+function mulDiv(T a, T b, uintN divisor) internal returns (T)
+function mulDiv(T a, uintN b, uintN divisor) internal returns (T)
+```
+
+Returns `(a * b) / divisor` for `euint8`, `euint16`, `euint32` and `euint64`. The product is computed on twice the operand width, so it cannot overflow before the division. The divisor is always a plaintext and must be non-zero (`DivisionByZero` otherwise). Typical use: `amount * numerator / denominator` without intermediate overflow.
+
+#### Sum of an array - `sum`
+
+```solidity
+function sum(T[] memory values) internal returns (T)
+```
+
+Returns the wrapped sum of all elements, for `euint8` to `euint128`. Elements must share one type. At most 100 elements for `euint8`, `euint16` and `euint32`, 60 for `euint64` and `euint128`. Cheaper than a chain of `add` calls.
 
 #### Min/Max Operations - `min`, `max`
 
@@ -258,6 +280,14 @@ function gt(uint32 a, euint16 b) internal view returns (ebool)
 function gt(euint16 a, uint32 b) internal view returns (ebool)
 ```
 
+#### Set membership - `isIn`
+
+```solidity
+function isIn(T value, T[] memory set) internal returns (ebool)
+```
+
+Returns an encrypted `true` if `value` equals one of the elements of `set`, without revealing which one. Available on all `euintX` types and on `eaddress`. At most 100 elements for `euint8`, `euint16` and `euint32`, 60 for wider types and `eaddress`. An empty set yields `false`.
+
 ### Multiplexer operator (`select`)
 
 ```solidity
@@ -283,11 +313,19 @@ Random encrypted integers can be generated fully on-chain.
 
 That can only be done during transactions and not on an `eth_call` RPC method, because PRNG state needs to be mutated on-chain during generation.
 
+```solidity
+function randEbool() internal returns (ebool)
+function randEuintX() internal returns (euintX)                 // uniform on X bits
+function randEuintX(uintX upperBound) internal returns (euintX) // uniform in [0, upperBound - 1]
+```
+
+`upperBound` must be a power of two (`NotPowerOfTwo` otherwise) and fit the type (`UpperBoundAboveMaxTypeValue`). There is no random `eaddress`. See [Generate random numbers](operations/random.md) for guarantees and the arbitrary-range patterns.
+
 #### Example
 
 ```solidity
-// Generate a random encrypted unsigned integer `r`.
-euint32 r = FHE.randEuint32();
+euint32 r = FHE.randEuint32();      // 0 .. 2^32 - 1
+euint8 dice = FHE.randEuint8(8);    // 0 .. 7
 ```
 
 ## Access control functions
@@ -449,6 +487,15 @@ Prefer `checkSignatures` over this function in most cases. `checkSignatures` is 
 Neither function provides replay protection on its own — emitting an event does not prevent the same `(handles, cleartexts, proof)` triple from being submitted twice. The callback that consumes the cleartexts must implement its own replay/state guard (see [Public Decryption](decryption/oracle.md)).
 {% endhint %}
 
+### Inspect the KMS context of a proof
+
+```solidity
+function getContextSignersAndThresholdFromExtraData(bytes memory extraData)
+    internal view returns (address[] memory signers, uint256 threshold)
+```
+
+Resolves the `extraData` tail of a decryption proof into the KMS signer set and threshold the proof will be checked against. Reverts if the referenced KMS context does not exist or has been destroyed. Mostly useful for monitoring and tests; see [Verifying public decryptions](decryption/verification.md) for the proof layout.
+
 ### Convert to bytes32
 
 ```solidity
@@ -545,6 +592,16 @@ function isAccountDenied(address account) internal view returns (bool)
 
 Returns whether the given account is on the deny list. Denied accounts cannot interact with encrypted values.
 
+## Confidential bridge
+
+```solidity
+function getLZConfidentialBridgeAddress() internal view returns (address)
+function quoteLZConfidentialBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint64 lzComposeGas) internal view returns (uint256 nativeFee)
+function sendLZConfidentialBridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint64 lzComposeGas, uint256 nativeFee) internal returns (bytes32 guid, uint64 nonce)
+```
+
+Move up to 32 encrypted handles to a contract on another host chain through the Zama `ConfidentialBridge` (LayerZero). The fee must be quoted right before sending and matched exactly. Most applications should inherit `ConfidentialOApp` instead of calling these directly; see [Confidential bridge](bridge.md).
+
 ## Additional notes
 
 - **Underlying implementation**:\
@@ -553,3 +610,5 @@ Returns whether the given account is on the deny list. Denied accounts cannot in
   Uninitialized encrypted values are treated as `0` (for integers) or `false` (for booleans) in computations.
 - **Implicit casting**:\
   Type conversion between encrypted integers of different bit widths is supported through implicit casting, allowing seamless operations without additional developer intervention.
+- **Exact behaviour**:\
+  Overflow, division by zero, shift amounts, casts and size limits are specified in [Operator semantics](operations/semantics.md).

--- a/docs/solidity-guides/hcu.md
+++ b/docs/solidity-guides/hcu.md
@@ -84,7 +84,9 @@ HCU increase with the bit-width of the encrypted integer type. Below are the det
 | `neg`          | -            | 79,000           |
 | `not`          | -            | 9                |
 | `select`       | -            | 55,000           |
+| `mulDiv`       | 495,000      | 524,000          |
 | `randEuint8`   | -            | 23,000           |
+| `randEuint8(bound)` | -       | 23,000           |
 
 #### **16-bit Encrypted integers (`euint16`)**
 
@@ -113,7 +115,9 @@ HCU increase with the bit-width of the encrypted integer type. Below are the det
 | `neg`           | -            | 93,000           |
 | `not`           | -            | 16               |
 | `select`        | -            | 55,000           |
+| `mulDiv`        | 703,000      | 766,000          |
 | `randEuint16`   | -            | 23,000           |
+| `randEuint16(bound)` | -       | 23,000           |
 
 #### **32-bit Encrypted Integers (`euint32`)**
 
@@ -142,7 +146,9 @@ HCU increase with the bit-width of the encrypted integer type. Below are the det
 | `neg`           | -            | 131,000          |
 | `not`           | -            | 32               |
 | `select`        | -            | 55,000           |
+| `mulDiv`        | 1,080,000    | 1,311,000        |
 | `randEuint32`   | -            | 24,000           |
+| `randEuint32(bound)` | -       | 24,000           |
 
 #### **64-bit Encrypted integers (`euint64`)**
 
@@ -171,7 +177,9 @@ HCU increase with the bit-width of the encrypted integer type. Below are the det
 | `neg`           | -            | 131,000          |
 | `not`           | -            | 63               |
 | `select`        | -            | 55,000           |
+| `mulDiv`        | 1,921,000    | 2,911,000        |
 | `randEuint64`   | -            | 24,000           |
+| `randEuint64(bound)` | -       | 24,000           |
 
 #### **128-bit Encrypted integers (`euint128`)**
 
@@ -201,6 +209,7 @@ HCU increase with the bit-width of the encrypted integer type. Below are the det
 | `not`            | -            | 130              |
 | `select`         | -            | 57,000           |
 | `randEuint128`   | -            | 25,000           |
+| `randEuint128(bound)` | -       | 25,000           |
 
 #### **256-bit Encrypted integers (`euint256`)**
 
@@ -219,6 +228,33 @@ HCU increase with the bit-width of the encrypted integer type. Below are the det
 | `not`            | -            | 130              |
 | `select`         | -            | 108,000          |
 | `randEuint256`   | -            | 30,000           |
+| `randEuint256(bound)` | -       | 30,000           |
+
+#### N-ary operations (`sum`, `isIn`)
+
+`FHE.sum` and `FHE.isIn` are priced by the number of elements they process. The cost is bucketed: an array of `n` elements is charged the price of the smallest bucket that fits `n`. Arrays longer than the last bucket for a type are rejected (`FHECollectionSizeInvalid`).
+
+**`sum(values)`**
+
+| Type       | n ≤ 10  | n ≤ 30  | n ≤ 60  | n ≤ 100 |
+| ---------- | ------- | ------- | ------- | ------- |
+| `euint8`   | 90,900  | 127,000 | 148,000 | 159,000 |
+| `euint16`  | 95,000  | 136,000 | 162,000 | 184,000 |
+| `euint32`  | 116,000 | 164,000 | 205,000 | 281,000 |
+| `euint64`  | 139,000 | 216,000 | 306,000 | -       |
+| `euint128` | 219,000 | 355,000 | 552,000 | -       |
+
+**`isIn(value, set)`** (n is the set size)
+
+| Type       | n ≤ 10  | n ≤ 30  | n ≤ 60  | n ≤ 100 |
+| ---------- | ------- | ------- | ------- | ------- |
+| `euint8`   | 71,300  | 148,000 | 247,000 | 374,000 |
+| `euint16`  | 103,000 | 218,000 | 378,000 | 605,000 |
+| `euint32`  | 137,000 | 300,000 | 531,000 | 827,000 |
+| `euint64`  | 218,000 | 492,000 | 879,000 | -       |
+| `euint128` | 256,000 | 535,000 | 921,000 | -       |
+| `eaddress` | 286,000 | 584,000 | 885,000 | -       |
+| `euint256` | 321,000 | 586,000 | 943,000 | -       |
 
 #### **Encrypted addresses (`euint160`)**
 
@@ -230,9 +266,13 @@ When using `eaddress` (internally represented as `euint160`), the HCU costs for 
 | `ne`          | 115,000      | 124,000          |
 | `select`      | -            | 83,000           |
 
+For `isIn` on `eaddress`, see the n-ary table above.
+
 ## Additional Operations
 
 | Function name    | HCU           |
 | ---------------- | ------------- |
 | `cast`           | 32            |
 | `trivialEncrypt` | 32            |
+
+`mulDiv` is priced as a multiplication plus a division on the doubled width (`mulDiv` on `euint64` costs about a `mul` plus a `div` on 128 bits), which is why it is the most expensive binary operator.

--- a/docs/solidity-guides/migrating-to-0.15.md
+++ b/docs/solidity-guides/migrating-to-0.15.md
@@ -1,0 +1,58 @@
+# Migrating to v0.15
+
+This page lists what changes for Solidity developers between protocol v0.14 and v0.15, and what to check in existing contracts before the upgrade reaches the network you deploy on. It only covers the `@fhevm/solidity` library and the host contracts it talks to; SDK changes are documented in the [SDK guides](https://docs.zama.ai/protocol/relayer-sdk-guides).
+
+## Behaviour changes
+
+### Oversized shift amounts now return zero
+
+`FHE.shl(a, k)` and `FHE.shr(a, k)` with an amount `k` greater than or equal to the bit width `N` of `a`:
+
+| Version        | Result                                    |
+| -------------- | ----------------------------------------- |
+| up to v0.14    | shift by `k mod N` (`shr(euint64 x, 70)` equals `shr(x, 6)`) |
+| v0.15 and later | `0`, like `>>` and `<<` on Solidity `uintN` |
+
+This comes from TFHE-rs 1.7, which the coprocessors adopt with v0.15. It applies to both the plaintext and the encrypted amount overloads. Rotations (`rotl`, `rotr`) are **not** affected and keep reducing the amount modulo `N`.
+
+**What to check.** Search your contracts for `FHE.shl` and `FHE.shr`. If the amount is a constant below the width, nothing changes. If the amount is computed, user-provided or encrypted and can reach `N`, decide which semantics you want and make it explicit:
+
+```solidity
+// Keep the old wrap-around behaviour on both versions
+euint64 y = FHE.shr(x, FHE.rem(k, 64));   // encrypted amount
+euint64 z = FHE.shr(x, uint8(k % 64));    // plaintext amount
+
+// Or embrace the new one: any k >= 64 gives 0, no extra code needed on v0.15
+```
+
+Full specification: [Operator semantics](operations/semantics.md#shift-and-rotate-amounts).
+
+### Handle derivation
+
+Handles produced by v0.15 are derived differently from v0.14 for the same computation (the executor now distinguishes operand origins). This is only visible to code that assumed a relationship between handle bytes and the computation that produced them, which was never guaranteed. Contracts that follow [Handles](handles.md) are unaffected.
+
+## New in the library since v0.14
+
+These functions ship in `@fhevm/solidity` 0.14 and later and are now documented:
+
+| Function                                                     | What it does                                                           | Documentation                                         |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------- |
+| `FHE.mulDiv(a, b, divisor)`                                  | `(a * b) / divisor` without intermediate overflow                       | [Operator semantics](operations/semantics.md#muldiv)  |
+| `FHE.toExternal(value)`                                      | Re-wrap a handle as an input type for contract-to-contract calls        | [Encrypted inputs](inputs.md#re-exporting-a-handle-with-fhetoexternal) |
+| `FHE.sendLZConfidentialBridge`, `quoteLZConfidentialBridge`, `getLZConfidentialBridgeAddress` | Bridge handles to another host chain | [Confidential bridge](bridge.md)                      |
+| `ConfidentialOApp` base contracts                            | Peer registry, typed senders and a secured receiver for cross-chain apps | [Confidential bridge](bridge.md)                      |
+| `ZamaPolygonConfig`, `ZamaMultiChainConfig`                  | Configuration contracts for Polygon and multi-chain deployments          | [Configuration](configure.md)                          |
+
+`FHE.sum` and `FHE.isIn` predate v0.14 but were undocumented; they are now specified in [Operator semantics](operations/semantics.md).
+
+## Networks
+
+Polygon mainnet (chain id 137) and Polygon Amoy (80002) are supported host chains. Addresses are listed in [Contract addresses](contract_addresses.md). A contract compiled against `ZamaEthereumConfig` reverts at deployment on Polygon; switch to `ZamaPolygonConfig` or `ZamaMultiChainConfig`.
+
+## Checklist
+
+- [ ] No `FHE.shl` / `FHE.shr` depends on an amount that can reach the operand width, or the amount is reduced explicitly.
+- [ ] No code compares handle bytes to infer anything about the underlying computation.
+- [ ] Public decryption callbacks verify proofs with `FHE.checkSignatures` and carry their own replay guard ([Verifying public decryptions](decryption/verification.md)).
+- [ ] Contracts meant for several host chains inherit `ZamaMultiChainConfig`.
+- [ ] Tests that assert exact HCU consumption are re-run: costs for `mulDiv`, `sum` and `isIn` are listed in [HCU](hcu.md).

--- a/docs/solidity-guides/migrating-to-0.15.md
+++ b/docs/solidity-guides/migrating-to-0.15.md
@@ -41,18 +41,12 @@ These functions ship in `@fhevm/solidity` 0.14 and later and are now documented:
 | `FHE.toExternal(value)`                                      | Re-wrap a handle as an input type for contract-to-contract calls        | [Encrypted inputs](inputs.md#re-exporting-a-handle-with-fhetoexternal) |
 | `FHE.sendLZConfidentialBridge`, `quoteLZConfidentialBridge`, `getLZConfidentialBridgeAddress` | Bridge handles to another host chain | [Confidential bridge](bridge.md)                      |
 | `ConfidentialOApp` base contracts                            | Peer registry, typed senders and a secured receiver for cross-chain apps | [Confidential bridge](bridge.md)                      |
-| `ZamaPolygonConfig`, `ZamaMultiChainConfig`                  | Configuration contracts for Polygon and multi-chain deployments          | [Configuration](configure.md)                          |
 
 `FHE.sum` and `FHE.isIn` predate v0.14 but were undocumented; they are now specified in [Operator semantics](operations/semantics.md).
-
-## Networks
-
-Polygon mainnet (chain id 137) and Polygon Amoy (80002) are supported host chains. Addresses are listed in [Contract addresses](contract_addresses.md). A contract compiled against `ZamaEthereumConfig` reverts at deployment on Polygon; switch to `ZamaPolygonConfig` or `ZamaMultiChainConfig`.
 
 ## Checklist
 
 - [ ] No `FHE.shl` / `FHE.shr` depends on an amount that can reach the operand width, or the amount is reduced explicitly.
 - [ ] No code compares handle bytes to infer anything about the underlying computation.
 - [ ] Public decryption callbacks verify proofs with `FHE.checkSignatures` and carry their own replay guard ([Verifying public decryptions](decryption/verification.md)).
-- [ ] Contracts meant for several host chains inherit `ZamaMultiChainConfig`.
 - [ ] Tests that assert exact HCU consumption are re-run: costs for `mulDiv`, `sum` and `isIn` are listed in [HCU](hcu.md).

--- a/docs/solidity-guides/operations/README.md
+++ b/docs/solidity-guides/operations/README.md
@@ -1,5 +1,9 @@
 # Operations on encrypted types
 
+{% hint style="info" %}
+This page lists what is available. For the exact behaviour of each operator (overflow, division by zero, shift amounts, casts, size limits, errors), see [Operator semantics](semantics.md).
+{% endhint %}
+
 This document outlines the operations supported on encrypted types in the `FHE` library, enabling arithmetic, bitwise, comparison, and more on Fully Homomorphic Encryption (FHE) ciphertexts.
 
 ## Arithmetic operations
@@ -16,6 +20,10 @@ The following arithmetic operations are supported for encrypted integers (`euint
 | Negation                     | `FHE.neg`     | `-`    | Unary  |
 | Min                          | `FHE.min`     |        | Binary |
 | Max                          | `FHE.max`     |        | Binary |
+| Multiply then divide (plaintext divisor) | `FHE.mulDiv` |  | Ternary |
+| Sum of an array              | `FHE.sum`     |        | N-ary  |
+
+`FHE.mulDiv(a, b, d)` computes `(a * b) / d` on a doubled intermediate width, so the product cannot overflow before the division. `FHE.sum(values)` adds up to 100 encrypted values of the same type (60 for `euint64` and `euint128`) in a single operation. Both are specified in [Operator semantics](semantics.md).
 
 {% hint style="info" %}
 Division (FHE.div) and remainder (FHE.rem) operations are currently supported only with plaintext divisors.
@@ -36,6 +44,10 @@ The FHE library also supports bitwise operations, including shifts and rotations
 | Rotate Right | `FHE.rotr`    |        | Binary |
 | Rotate Left  | `FHE.rotl`    |        | Binary |
 
+{% hint style="warning" %}
+The shift amount is an 8-bit value. Up to protocol v0.14 an amount greater than or equal to the operand width is reduced modulo the width; **from v0.15 the result is `0`**, as in Solidity. Rotations always reduce the amount modulo the width. See [Operator semantics](semantics.md#shift-and-rotate-amounts) and [Migrating to v0.15](../migrating-to-0.15.md).
+{% endhint %}
+
 The shift operators `FHE.shr` and `FHE.shl` can take any encrypted type `euintX` as a first operand and either a `uint8`or a `euint8` as a second operand, however the second operand will always be computed modulo the number of bits of the first operand. For example, `FHE.shr(euint64 x, 70)` is equivalent to `FHE.shr(euint64 x, 6)` because `70 % 64 = 6`. This differs from the classical shift operators in Solidity, where there is no intermediate modulo operation, so for instance any `uint64` shifted right via `>>` would give a null result.
 
 ## Comparison operations
@@ -50,6 +62,9 @@ Encrypted integers can be compared using the following functions:
 | Greater than          | `FHE.gt`      |        | Binary |
 | Less than or equal    | `FHE.le`      |        | Binary |
 | Less than             | `FHE.lt`      |        | Binary |
+| Membership in a set   | `FHE.isIn`    |        | N-ary  |
+
+`FHE.isIn(value, set)` returns an `ebool` that is `true` when `value` equals one element of `set` (up to 100 elements, 60 for 64-bit and wider types), without revealing which one. It is available on every `euintX` type and on `eaddress`.
 
 ## Ternary operation
 

--- a/docs/solidity-guides/operations/random.md
+++ b/docs/solidity-guides/operations/random.md
@@ -1,63 +1,79 @@
 # Generate random numbers
 
-This document explains how to generate cryptographically secure random encrypted numbers fully on-chain using the `FHE` library in fhevm. These numbers are encrypted and remain confidential, enabling privacy-preserving smart contract logic.
+This document explains how to generate encrypted random values fully on-chain with the `FHE` library, what guarantees they carry, and how the bounded variant behaves. Random values are produced as ciphertexts: nobody, including the contract that requested them, learns the value until it is decrypted through the protocol.
 
-## **Key notes on random number generation**
+## Summary
 
-- **On-chain execution**: Random number generation must be executed during a transaction, as it requires the pseudo-random number generator (PRNG) state to be updated on-chain. This operation cannot be performed using the `eth_call` RPC method.
-- **Cryptographic security**: The generated random numbers are cryptographically secure and encrypted, ensuring privacy and unpredictability.
+| Function                           | Result   | Range                 | Notes                                                        |
+| ---------------------------------- | -------- | --------------------- | ------------------------------------------------------------ |
+| `FHE.randEbool()`                  | `ebool`  | `{false, true}`       |                                                              |
+| `FHE.randEuintX()`                 | `euintX` | `[0, 2^X - 1]`        | `X` in 8, 16, 32, 64, 128, 256                               |
+| `FHE.randEuintX(uintX upperBound)` | `euintX` | `[0, upperBound - 1]` | `upperBound` must be a power of two, `0 < upperBound <= 2^X` |
 
-{% hint style="info" %}
-Random number generation must be performed during transactions, as it requires the pseudo-random number generator (PRNG) state to be mutated on-chain. Therefore, it cannot be executed using the `eth_call` RPC method.
-{% endhint %}
+There is no random `eaddress` and no built-in random value for a non-power-of-two range. Both are deliberate, see [Bounded random numbers](#bounded-random-numbers).
 
-## **Basic usage**
+## Key notes
 
-The `FHE` library allows you to generate random encrypted numbers of various bit sizes. Below is a list of supported types and their usage:
+- **Transactions only.** Random generation mutates on-chain state (a counter that feeds the seed), so it can only run inside a transaction. Calling it through `eth_call` does not produce a usable handle.
+- **Encrypted output.** The result is a regular encrypted handle. It follows the same ACL rules as any other ciphertext: allow it to the contract with `FHE.allowThis` if you store it, allow it to a user if they must decrypt it.
+- **Cost.** Each call is metered in HCU like any other FHE operation (see [HCU](../hcu.md)). Generation is cheap compared to arithmetic: 19,000 HCU for `ebool` and 23,000 to 30,000 HCU for the integer types.
+
+## Basic usage
 
 ```solidity
-// Generate random encrypted numbers
-ebool rb = FHE.randEbool();       // Random encrypted boolean
-euint8 r8 = FHE.randEuint8();     // Random 8-bit number
-euint16 r16 = FHE.randEuint16();  // Random 16-bit number
-euint32 r32 = FHE.randEuint32();  // Random 32-bit number
-euint64 r64 = FHE.randEuint64();  // Random 64-bit number
-euint128 r128 = FHE.randEuint128(); // Random 128-bit number
-euint256 r256 = FHE.randEuint256(); // Random 256-bit number
+ebool rb = FHE.randEbool();          // random encrypted boolean
+euint8 r8 = FHE.randEuint8();        // uniform in [0, 255]
+euint16 r16 = FHE.randEuint16();     // uniform in [0, 65535]
+euint32 r32 = FHE.randEuint32();
+euint64 r64 = FHE.randEuint64();
+euint128 r128 = FHE.randEuint128();
+euint256 r256 = FHE.randEuint256();
 ```
 
-### **Example: Random Boolean**
+### Example: coin flip
 
 ```solidity
-function randomBoolean() public returns (ebool) {
-  return FHE.randEbool();
+function flip() external returns (ebool) {
+  ebool heads = FHE.randEbool();
+  FHE.allowThis(heads);
+  FHE.allow(heads, msg.sender);
+  return heads;
 }
 ```
 
-## **Bounded random numbers**
+## Bounded random numbers
 
-To generate random numbers within a specific range, you can specify an **upper bound**. The specified upper bound must be a power of 2. The random number will be in the range `[0, upperBound - 1]`.
-
-```solidity
-// Generate random numbers with upper bounds
-euint8 r8 = FHE.randEuint8(32);      // Random number between 0-31
-euint16 r16 = FHE.randEuint16(512);  // Random number between 0-511
-euint32 r32 = FHE.randEuint32(65536); // Random number between 0-65535
-```
-
-### **Example: Random number with upper bound**
+`FHE.randEuintX(upperBound)` returns a value uniformly distributed in `[0, upperBound - 1]`.
 
 ```solidity
-function randomBoundedNumber(uint16 upperBound) public returns (euint16) {
-  return FHE.randEuint16(upperBound);
-}
+euint8 dice = FHE.randEuint8(8);        // 0..7
+euint16 slot = FHE.randEuint16(1024);   // 0..1023
+euint64 idx = FHE.randEuint64(1 << 40); // 0..2^40 - 1
 ```
 
-## **Security Considerations**
+**The upper bound must be a power of two.** The call reverts on-chain with `NotPowerOfTwo` otherwise, and with `UpperBoundAboveMaxTypeValue` if the bound does not fit the result type. This restriction exists so that the result is **exactly uniform**: the coprocessor keeps the low `log2(upperBound)` bits of a full-width random value and clears the rest, which introduces no modulo bias. FHEVM deliberately does not expose the arbitrary-bound sampling of TFHE-rs, whose output is slightly biased.
 
-- **Cryptographic security**:\
-  The random numbers are generated using a cryptographically secure pseudo-random number generator (CSPRNG) and remain encrypted until explicitly decrypted.
-- **Gas consumption**:\
-  Each call to a random number generation function consumes gas. Developers should optimize the use of these functions, especially in gas-sensitive contracts.
-- **Privacy guarantee**:\
-  Random values are fully encrypted, ensuring they cannot be accessed or predicted by unauthorized parties.
+### Random number in an arbitrary range
+
+If you need a range `[0, n)` where `n` is not a power of two, you must build it yourself and accept one of two trade-offs:
+
+- **Rejection sampling across transactions.** Draw `r = FHE.randEuintX(nextPowerOfTwo(n))`, compute `FHE.lt(r, n)`, decrypt that boolean, and draw again in a later transaction if it is `false`. The result is uniform, but the number of rounds is not fixed.
+- **Modulo reduction.** Compute `FHE.rem(FHE.randEuintX(), n)` with a scalar `n`. Always one round, but slightly biased toward small values. The bias is bounded by `n / 2^X`, so pick a width `X` much larger than `log2(n)`: a six-sided die drawn from `euint64` has a bias below `2^-61`, the same die drawn from `euint8` has a bias of about 2 %.
+
+Document the choice in your contract. For games of chance or lotteries, prefer rejection sampling or a width large enough that the bias is negligible for your stakes.
+
+## What the randomness guarantees
+
+- **Source.** The seed is derived on-chain by the `FHEVMExecutor` from a domain separator, a counter that advances on every call, the ACL address, the chain id, the previous block hash and the block timestamp. The coprocessors expand that seed into an encrypted value with the TFHE-rs encrypted PRF, so the plaintext is never materialised anywhere.
+- **Unpredictability.** Nobody can read the value before an authorized decryption: not the contract, not the caller, not the coprocessor operators. Two calls in the same transaction produce independent values because the counter advances between them.
+- **Block producer influence.** Because the seed includes the previous block hash and the timestamp, a block producer has the usual, limited influence over which seed a transaction gets. They still cannot learn the resulting value. If your application must resist a block producer choosing between a handful of candidate outcomes, combine on-chain randomness with a commit-reveal scheme or with user-supplied encrypted inputs.
+- **Determinism across coprocessors.** All coprocessors derive the same ciphertext from the same seed, which is what lets a multi-coprocessor deployment reach consensus on the result.
+
+For the cryptographic construction of the encrypted PRF, see the [TFHE-rs documentation](https://docs.zama.ai/tfhe-rs/fhe-computation/advanced-features/encrypted-prf).
+
+## Common mistakes
+
+- **Reading the result in the same transaction.** You cannot branch on a random value on-chain except through `FHE.select`. To act on the clear value, request a public or user decryption and continue in a later transaction.
+- **Forgetting the ACL.** A random handle stored without `FHE.allowThis` cannot be used by your contract in the next transaction.
+- **Using `rem` with a narrow type.** `FHE.rem(FHE.randEuint8(), 6)` is visibly biased. Draw from a wider type first.
+- **Expecting a random `eaddress`.** There is none; a random 160-bit value would not be a valid, funded account anyway.

--- a/docs/solidity-guides/operations/semantics.md
+++ b/docs/solidity-guides/operations/semantics.md
@@ -1,0 +1,154 @@
+# Operator semantics
+
+This page is the reference for what each `FHE` operator computes, which operand shapes it accepts, and what happens at the edges: overflow, division by zero, oversized shift amounts, narrowing casts. Treat it as the specification the [operations overview](README.md) summarises. Behaviour is the same on every host chain and with every number of coprocessors, because the coprocessors must agree on results.
+
+## Notation
+
+- `euintN` is an encrypted unsigned integer of `N` bits, `N` in {8, 16, 32, 64, 128, 256}. `eaddress` is an alias for a 160-bit encrypted integer. `ebool` is an encrypted boolean.
+- "Scalar" means a plaintext Solidity value (`uintN`, `bool`, `address`) passed directly to the operator.
+- All integer arithmetic below is unsigned and performed modulo `2^N`.
+
+## General rules
+
+**Every operation is a transaction.** Calling an operator records a computation request on-chain and returns a new handle immediately; the coprocessors compute the ciphertext asynchronously. A function that performs FHE operations cannot be `view`, and the caller must be [allowed](../acl/README.md) on every encrypted operand, otherwise the call reverts with `ACLNotAllowed`.
+
+**Uninitialised operands.** A handle that was never assigned (`bytes32(0)`) is treated by the library as a trivial encryption of `0` (or `false`). Use `FHE.isInitialized` when this default is not what you want.
+
+**Mixed widths.** Binary operators accept two encrypted operands of different widths. The narrower operand is implicitly zero-extended and the result takes the wider type: `FHE.add(euint8, euint32)` returns `euint32`. This applies to arithmetic, bitwise, comparison and `min`/`max`. It does **not** apply to `select`, whose two branches must have exactly the same type.
+
+**Scalar operands.** Most binary operators accept one plaintext operand. The backend only accepts a plaintext on the right, so `FHE.add(3, x)` is rewritten as `FHE.add(x, 3)` and `FHE.gt(3, x)` as `FHE.lt(x, 3)`. The scalar width must not exceed the encrypted width (`add(uint32, euint16)` does not compile). Scalar variants are significantly cheaper in HCU; prefer them whenever one operand is public.
+
+**Results are always fresh handles.** Two calls with the same inputs return different handles (see [Handles](../handles.md)). Never compare handles to test equality of values; use `FHE.eq`.
+
+**No information leaks through failure.** Operators never revert because of the encrypted values themselves. The reverts listed below depend only on public data: operand types, scalar values, array lengths and ACL state.
+
+## Arithmetic
+
+| Operator                 | Result                           | Notes                                                                     |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------------- |
+| `add(a, b)`              | `(a + b) mod 2^N`                | Wraps silently on overflow.                                               |
+| `sub(a, b)`              | `(a - b) mod 2^N`                | Wraps silently on underflow: `sub(0, 1)` is `2^N - 1`.                    |
+| `mul(a, b)`              | `(a * b) mod 2^N`                | Wraps silently on overflow.                                               |
+| `div(a, s)`              | `floor(a / s)`                   | `s` **must be a scalar**. `s == 0` reverts with `DivisionByZero`.        |
+| `rem(a, s)`              | `a mod s`                        | Same constraints as `div`. `a == div(a, s) * s + rem(a, s)` always holds. |
+| `neg(a)`                 | `(2^N - a) mod 2^N`              | Two's complement negation. `neg(0)` is `0`.                               |
+| `min(a, b)`, `max(a, b)` | smallest / largest value         |                                                                           |
+| `mulDiv(a, b, s)`        | `floor((a * b) / s)` on 2N bits  | `s` **must be a scalar**, non-zero. See below.                            |
+| `sum(values)`            | `(v_0 + ... + v_k) mod 2^N`      | Fixed-size array of one type. See below.                                  |
+
+Overflow is unchecked by design: a checked operation would have to reveal whether the overflow happened. When an overflow must be detected, test for it explicitly and neutralise it with `FHE.select`, as shown in the [overflow pattern](README.md#beware-of-overflows-of-fhe-arithmetic-operators).
+
+Division and remainder by an **encrypted** divisor are not available. The only overloads are `div(euintN, uintN)` and `rem(euintN, uintN)`, for `N` up to 128.
+
+### `mulDiv`
+
+```solidity
+function mulDiv(euintN a, euintN b, uintN divisor) internal returns (euintN)
+function mulDiv(euintN a, uintN b, uintN divisor) internal returns (euintN)
+```
+
+Computes `floor((a * b) / divisor)` for `N` in {8, 16, 32, 64}. The product is formed on `2N` bits, so it cannot overflow before the division; the quotient is then brought back to `N` bits, wrapping if it does not fit. Use it for proportional splits (`amount * share / totalShares`) where the intermediate product would overflow a plain `mul`. A zero `divisor` reverts with `DivisionByZero`. The divisor is always public; the first factor is always encrypted; the second factor may be either.
+
+Cost is roughly a `mul` plus a `div` on the doubled width, see [HCU](../hcu.md).
+
+### `sum`
+
+```solidity
+function sum(euintN[] memory values) internal returns (euintN)
+```
+
+Adds all elements of `values` and returns the wrapped sum, for `N` in {8, 16, 32, 64, 128}. All elements must have the same type (`IncompatibleTypes` otherwise). The array length is capped by the executor: at most **100** elements for `euint8`, `euint16` and `euint32`, at most **60** for `euint64` and `euint128`; larger arrays revert with `FHECollectionSizeInvalid`. An empty array returns a trivial encryption of `0`. `sum` is cheaper than a chain of `add` calls and produces a single handle.
+
+## Bitwise
+
+| Operator             | Result                          | Notes                                                                 |
+| -------------------- | ------------------------------- | --------------------------------------------------------------------- |
+| `and`, `or`, `xor`   | bitwise                         | Also available on `ebool`. Scalar variants trivially encrypt the scalar first. |
+| `not(a)`             | flips all `N` bits              | On `ebool`, logical negation.                                          |
+| `shl(a, k)`          | `(a << k) mod 2^N`              | `k` is `euint8` or `uint8`. See shift amount rules.                   |
+| `shr(a, k)`          | `a >> k` (logical, fills with 0) | `k` is `euint8` or `uint8`.                                            |
+| `rotl(a, k)`         | rotate left by `k mod N`        |                                                                       |
+| `rotr(a, k)`         | rotate right by `k mod N`       |                                                                       |
+
+### Shift and rotate amounts
+
+The shift amount is always an 8-bit value, encrypted or not, whatever the width of the first operand. What happens when the amount is **greater than or equal to `N`** depends on the protocol version:
+
+| Protocol version | `shl(a, k)` / `shr(a, k)` with `k >= N`               | `rotl` / `rotr` |
+| ---------------- | ------------------------------------------------------ | --------------- |
+| up to v0.14      | amount reduced modulo `N`: `shr(euint64 x, 70) == shr(x, 6)` | `k mod N`       |
+| **v0.15 and later** | **result is `0`**, matching Solidity `>>` and `<<` on `uintN` | `k mod N` (unchanged) |
+
+{% hint style="warning" %}
+This is a behaviour change in v0.15, inherited from TFHE-rs 1.7. Contracts that relied on the modulo behaviour for oversized shift amounts compute different results after the upgrade. If your shift amounts can reach `N`, reduce them yourself (`k % N` on a scalar, or `FHE.rem(k, N)`) so the code behaves identically before and after. See [Migrating to v0.15](../migrating-to-0.15.md).
+{% endhint %}
+
+Rotations keep the modulo semantics in every version. Because every `euintN` width is a power of two, `k mod N` is exact.
+
+## Comparisons
+
+| Operator                                  | Result  | Available on                     |
+| ----------------------------------------- | ------- | -------------------------------- |
+| `eq(a, b)`, `ne(a, b)`                    | `ebool` | all encrypted types, `eaddress` included |
+| `lt`, `le`, `gt`, `ge`                    | `ebool` | `euintN`                          |
+| `isIn(value, set)`                        | `ebool` | `euintN` and `eaddress`           |
+
+Comparisons are unsigned. With a scalar on the left the library swaps operands and the comparison, so `FHE.gt(5, x)` returns the same value as `FHE.lt(x, 5)`.
+
+### `isIn`
+
+```solidity
+function isIn(euintN value, euintN[] memory set) internal returns (ebool)
+function isIn(eaddress value, eaddress[] memory set) internal returns (ebool)
+```
+
+Returns an encrypted `true` if `value` equals at least one element of `set`, `false` otherwise, without revealing which element matched. An empty set returns an encrypted `false`. All elements must have the type of `value`. The set size is capped at **100** elements for `euint8`, `euint16` and `euint32`, and **60** for `euint64`, `euint128`, `eaddress` and `euint256` (`FHECollectionSizeInvalid` otherwise). Typical uses: encrypted allow-lists, checking a hidden choice against a small menu of encrypted options.
+
+## Selection
+
+```solidity
+function select(ebool control, T a, T b) internal returns (T)
+```
+
+Returns `a` if `control` is `true`, `b` otherwise. Both branches are always evaluated: `select` is a multiplexer, not a jump, so it cannot short-circuit and cannot leak which branch was taken. `a` and `b` must have exactly the same type; cast one of them explicitly if they differ. This is the only way to branch on encrypted data; see [Branching](../logics/conditions.md).
+
+## Casting and trivial encryption
+
+| Call                    | Behaviour                                                                          |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| `asEuintM(euintN x)`, `M < N` | **Truncation**: keeps the low `M` bits.                                       |
+| `asEuintM(euintN x)`, `M > N` | Zero-extension.                                                              |
+| `asEbool(euintN x)`     | `x != 0`.                                                                          |
+| `asEuintN(ebool b)`     | `1` if `true`, `0` otherwise.                                                      |
+| `asEuintN(uintN v)`     | **Trivial encryption** of the public value `v`. Not confidential: `v` is visible on-chain. |
+| `asEaddress(address a)` | Trivial encryption of a public address.                                            |
+| `asEbool(bool b)`       | Trivial encryption of a public boolean.                                            |
+
+Casting a value to its own type reverts with `InvalidType`. Trivially encrypted values are useful as constants in computations and cost almost nothing (32 HCU), but they carry no secrecy whatsoever.
+
+## Random values
+
+See [Generate random numbers](random.md). Bounded generation requires a power-of-two bound and is exactly uniform.
+
+## Public errors
+
+| Error                                   | Raised when                                                                 |
+| --------------------------------------- | --------------------------------------------------------------------------- |
+| `ACLNotAllowed(handle, account)`        | The calling contract is not allowed on an operand.                          |
+| `DivisionByZero()`                      | Scalar divisor of `div`, `rem` or `mulDiv` is zero.                         |
+| `IncompatibleTypes()`                   | Operands of an n-ary operator (`sum`, `isIn`) do not share a type.          |
+| `UnsupportedType()`                     | The operator does not exist for this type (for example `add` on `euint256`). |
+| `IsNotScalar()`                         | `div` or `rem` called with an encrypted divisor at the executor level.      |
+| `FHECollectionSizeInvalid(size, limit)` | `sum` or `isIn` array longer than the cap.                                  |
+| `NotPowerOfTwo()`, `UpperBoundAboveMaxTypeValue()` | Invalid bound for `randEuintN(upperBound)`.                      |
+| `InvalidType()`                         | Cast to the same type.                                                      |
+
+## Supported operators per type
+
+| Type                   | Arithmetic                                        | Bitwise                                    | Comparison                          | Other                              |
+| ---------------------- | ------------------------------------------------- | ------------------------------------------ | ----------------------------------- | ---------------------------------- |
+| `ebool`                |                                                   | `and`, `or`, `xor`, `not`                  | `eq`, `ne`                          | `select`, `rand`                   |
+| `euint8` to `euint64`  | `add`, `sub`, `mul`, `div`, `rem`, `neg`, `min`, `max`, `mulDiv`, `sum` | all, including shifts and rotations | all, `isIn`                         | `select`, `rand`, `randBounded`    |
+| `euint128`             | `add`, `sub`, `mul`, `div`, `rem`, `neg`, `min`, `max`, `sum` | all                                | all, `isIn`                         | `select`, `rand`, `randBounded`    |
+| `eaddress`             |                                                   |                                            | `eq`, `ne`, `isIn`                  | `select`                           |
+| `euint256`             | `neg`                                             | all                                        | `eq`, `ne`, `isIn`                  | `select`, `rand`, `randBounded`    |

--- a/docs/solidity-guides/types.md
+++ b/docs/solidity-guides/types.md
@@ -10,11 +10,7 @@ The `FHE` library offers a robust type system with encrypted integer types, enab
 
 - Encrypted integers function similarly to Solidity’s native integer types, but they operate on **Fully Homomorphic Encryption (FHE)** ciphertexts.
 - Arithmetic operations on `e(u)int` types are **unchecked**, meaning they wrap around on overflow. This design choice ensures confidentiality by avoiding the leakage of information through error detection.
-- Future versions of the `FHE` library will support encrypted integers with overflow checking, but with the trade-off of exposing limited information about the operands.
-
-{% hint style="info" %}
-Encrypted integers with overflow checking will soon be available in the `FHE` library. These will allow reversible arithmetic operations but may reveal some information about the input values.
-{% endhint %}
+- There is no checked arithmetic: detecting an overflow would reveal information about the operands. When an overflow must be handled, test for it with a comparison and neutralise it with `FHE.select` (see [Operator semantics](operations/semantics.md#arithmetic)).
 
 Encrypted integers in FHEVM are represented as FHE ciphertexts, abstracted using ciphertext handles. These types, prefixed with `e` (for example, `euint64`) act as secure wrappers over the ciphertext handles.
 
@@ -25,18 +21,20 @@ The `FHE` library currently supports the following encrypted types:
 | Type     | Bit Length | Supported Operators                                                                                                                | Aliases (with supported operators) |
 | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | Ebool    | 2          | and, or, xor, eq, ne, not, select, rand                                                                                            |                                    |
-| Euint8   | 8          | add, sub, mul, div, rem, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, min, max, neg, not, select, rand, randBounded |                                    |
-| Euint16  | 16         | add, sub, mul, div, rem, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, min, max, neg, not, select, rand, randBounded |                                    |
-| Euint32  | 32         | add, sub, mul, div, rem, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, min, max, neg, not, select, rand, randBounded |                                    |
-| Euint64  | 64         | add, sub, mul, div, rem, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, min, max, neg, not, select, rand, randBounded |                                    |
-| Euint128 | 128        | add, sub, mul, div, rem, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, min, max, neg, not, select, rand, randBounded |                                    |
-| Euint160 | 160        | eq, ne, select                                                                                                                     | Eaddress — `eaddress` is an alias for `euint160`, used for encrypted Ethereum addresses |
-| Euint256 | 256        | and, or, xor, shl, shr, rotl, rotr, eq, ne, neg, not, select, rand, randBounded                                                    |                                    |
+| Euint8   | 8          | add, sub, mul, div, rem, mulDiv, sum, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, isIn, min, max, neg, not, select, rand, randBounded |                                    |
+| Euint16  | 16         | add, sub, mul, div, rem, mulDiv, sum, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, isIn, min, max, neg, not, select, rand, randBounded |                                    |
+| Euint32  | 32         | add, sub, mul, div, rem, mulDiv, sum, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, isIn, min, max, neg, not, select, rand, randBounded |                                    |
+| Euint64  | 64         | add, sub, mul, div, rem, mulDiv, sum, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, isIn, min, max, neg, not, select, rand, randBounded |                                    |
+| Euint128 | 128        | add, sub, mul, div, rem, sum, and, or, xor, shl, shr, rotl, rotr, eq, ne, ge, gt, le, lt, isIn, min, max, neg, not, select, rand, randBounded |                                    |
+| Euint160 | 160        | eq, ne, isIn, select                                                                                                               | Eaddress — `eaddress` is an alias for `euint160`, used for encrypted Ethereum addresses |
+| Euint256 | 256        | and, or, xor, shl, shr, rotl, rotr, eq, ne, isIn, neg, not, select, rand, randBounded                                              |                                    |
 
 {% hint style="info" %}  
-Division (`div`) and remainder (`rem`) operations are only supported when the right-hand side (`rhs`) operand is a plaintext (non-encrypted) value. Attempting to use an encrypted value as `rhs` will result in a panic. This restriction ensures correct and secure computation within the current framework.
+Division (`div`), remainder (`rem`) and the divisor of `mulDiv` are only supported with a plaintext (non-encrypted) right-hand side: there is no overload taking an encrypted divisor, so such code does not compile. A plaintext divisor equal to zero reverts on-chain with `DivisionByZero`.
 {% endhint %}
 
 {% hint style="info" %}
 Higher-precision integer types are available in the `TFHE-rs` library and can be added to `fhevm` as needed.
 {% endhint %}
+
+The exact behaviour of each operator (wrapping, shifts, casts, size limits) is specified in [Operator semantics](operations/semantics.md).


### PR DESCRIPTION
## Why

The Solidity guides have not changed since the v0.14.0 tag while `library-solidity` and `host-contracts` did. Following the #tfhe-rs thread on documentation gaps (Rand, Thomas, Arthur), this PR brings the guides up to what ships in v0.15 and turns the operations pages into a specification developers can rely on, not just a list of names.

## What

New pages
- `operations/semantics.md`: per-operator specification. Mixed widths and scalar rules, wrapping arithmetic, `div`/`rem` with scalar divisor and `DivisionByZero`, `mulDiv` (2N-bit intermediate), `sum` and `isIn` with their size caps (100 / 60), shift and rotate amounts **including the v0.15 overshift change**, casts (truncation), public errors, type × operator matrix.
- `decryption/verification.md`: decryption proof layout, `extraData` versions (v0, v1, v2), KMS contexts, `checkSignatures` vs `isPublicDecryptionResultValid`, replay protection.
- `bridge.md`: `ConfidentialOApp` base contracts and `FHE.*LZConfidentialBridge`, constraints and error names. The `CrossChainCounter` example compiles with `forge build`.
- `migrating-to-0.15.md`: behaviour changes, what is new since v0.14, checklist.

Updated pages
- `operations/random.md` rewritten: power-of-two bound and exact uniformity, arbitrary-range patterns with the bias quantified, seed derivation and guarantees.
- `operations/README.md`, `types.md`, `functions.md`, `hcu.md`: `mulDiv`, `sum`, `isIn`, `toExternal`, bounded rand, `getContextSignersAndThresholdFromExtraData`, bridge functions; HCU tables gain `mulDiv`, bounded rand and bucketed n-ary costs from `operatorsPrices.ts`.
- `configure.md`, `contract_addresses.md`: `getCoprocessorConfig` routing, protocol ids, `ZamaProtocolUnsupported`, `PROTOCOL_CONFIG` addresses.
- `types.md`: removed the stale "checked arithmetic coming soon" note.
- `SUMMARY.md`: new pages registered.

## Points to confirm before merge

1. The shift semantics change assumes v0.15 ships with tfhe-rs 1.8 (overshift returns 0). `OVERSHIFT_RETURNS_ZERO` is still `false` in `test-suite/e2e/test/fhevmOperations/shiftSemantics.ts` and the coprocessor is on 1.6.3 on `main`. If the bump does not land before the freeze, drop that section from `semantics.md` and `migrating-to-0.15.md`.
2. Shuffle is planned coprocessor-side for v0.15 but is not in `FHE.sol` on `main`; not documented here.

## Checks

- Error names cited exist in `library-solidity/lib` and `host-contracts/contracts`.
- Relative links and anchors in `docs/solidity-guides` resolve (one pre-existing broken anchor in the quick-start is untouched).
- Bridge example compiled with forge against the current library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
