### PR TITLE
fix(coprocessor): move Gateway transport to HTTP

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -324,6 +324,23 @@ jobs:
           fi
           ./fhevm-cli up "${args[@]}" --dry-run
 
+      - name: Pull database image with retries
+        shell: bash
+        run: |
+          # Pre-pull the image from the compose file so a transient registry
+          # failure does not abort stack startup after other services start.
+          image="$(awk '$1 == "image:" { print $2; exit }' test-suite/fhevm/docker-compose/database-docker-compose.yml)"
+          for attempt in 1 2 3; do
+            if docker pull "$image"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Database image pull failed after three attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 10))"
+          done
+
       - name: Boot fhevm Stack
         working-directory: test-suite/fhevm
         run: |

--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.12.1
+version: 0.12.2
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/templates/coprocessor-tx-sender-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-tx-sender-deployment.yaml
@@ -150,7 +150,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
-            {{- with .Values.commonConfig.gatewayUrl }}
+            {{- with (.Values.txSender.config.gatewayUrl | default .Values.commonConfig.gatewayUrl) }}
             - name: GATEWAY_URL
               {{- if .value }}
               value: {{ .value | quote }}

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -1153,6 +1153,11 @@ txSender:
 
   # Component-specific configuration
   config:
+    # Sender-specific Gateway URL; accepts value or valueFrom. HTTP sender
+    # builds require http(s) here while commonConfig.gatewayUrl can remain
+    # ws(s) for gwListener. Unset falls back to commonConfig.gatewayUrl.
+    gatewayUrl: {}
+
     # Host chain RPC URL for v0.11 delegation management. Rendered as
     # HOST_CHAIN_URL and referenced by the built-in --host-chain-url arg when
     # set. Accepts `value` or `valueFrom` (secretKeyRef/configMapKeyRef).

--- a/coprocessor/fhevm-engine/.cargo/audit.toml
+++ b/coprocessor/fhevm-engine/.cargo/audit.toml
@@ -3,7 +3,16 @@
 
 [advisories]
 # The ignored vulnerability RUSTSEC-2024-0388 is due to sqlx-mysql which is not used
-ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0111"]
+ignore = [
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2025-0111",
+    # Temporary 0.13.x release exception: ruint shift overflow/truncation.
+    # Remove after upgrading ruint to >=1.20.0.
+    "RUSTSEC-2026-0220",
+    # Temporary 0.13.x release exception: h2 unbounded empty DATA frames.
+    # Covers both locked h2 versions; remove after migrating both to >=0.4.16.
+    "RUSTSEC-2026-0258",
+]
 # RUSTSEC-2025-0111 impacts only testcontainers
 informational_warnings = ["unmaintained"]
 severity_threshold = "medium"

--- a/coprocessor/fhevm-engine/.sqlx/query-8306a3117d63fd927b25869c9ee986374282e2748e31bbd52cf690e3b1ce6696.json
+++ b/coprocessor/fhevm-engine/.sqlx/query-8306a3117d63fd927b25869c9ee986374282e2748e31bbd52cf690e3b1ce6696.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE verify_proofs SET last_retry_at = NOW() WHERE zk_proof_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8306a3117d63fd927b25869c9ee986374282e2748e31bbd52cf690e3b1ce6696"
+}

--- a/coprocessor/fhevm-engine/.sqlx/query-88482f32cd374bd964df8a1c98d0ebc1cf1213c083190b297a8060392bbbf5e6.json
+++ b/coprocessor/fhevm-engine/.sqlx/query-88482f32cd374bd964df8a1c98d0ebc1cf1213c083190b297a8060392bbbf5e6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count, extra_data, transaction_id\n             FROM verify_proofs\n             WHERE verified IS NOT NULL AND retry_count < $1\n             ORDER BY zk_proof_id\n             LIMIT $2",
+  "query": "SELECT zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count, extra_data, transaction_id\n             FROM verify_proofs\n             WHERE verified IS NOT NULL AND retry_count < $1\n               AND (last_retry_at IS NULL OR last_retry_at <= NOW() - make_interval(secs => $3))\n             ORDER BY COALESCE(last_retry_at, created_at), zk_proof_id\n             LIMIT $2",
   "describe": {
     "columns": [
       {
@@ -52,7 +52,8 @@
     "parameters": {
       "Left": [
         "Int4",
-        "Int8"
+        "Int8",
+        "Float8"
       ]
     },
     "nullable": [
@@ -67,5 +68,5 @@
       true
     ]
   },
-  "hash": "9c32675069536c1825f8e161677a3d1c443a66514312fa099d0818cbbcfdf400"
+  "hash": "88482f32cd374bd964df8a1c98d0ebc1cf1213c083190b297a8060392bbbf5e6"
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -66,6 +66,17 @@ pub fn init_json_subscriber(
     service_name: &str,
     tracer_name: &'static str,
 ) -> Result<Option<TracerProviderGuard>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    init_json_subscriber_with_filter(log_level, service_name, tracer_name, |_| true)
+}
+
+/// An additional global metadata filter applies to both JSON logging and OTLP
+/// spans. Callers can suppress dependencies that log credential-bearing URLs.
+pub fn init_json_subscriber_with_filter(
+    log_level: tracing::Level,
+    service_name: &str,
+    tracer_name: &'static str,
+    metadata_filter: fn(&tracing::Metadata<'_>) -> bool,
+) -> Result<Option<TracerProviderGuard>, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let level_filter = tracing_subscriber::filter::LevelFilter::from_level(log_level);
     let fmt_layer = tracing_subscriber::fmt::layer()
         .json()
@@ -75,6 +86,7 @@ pub fn init_json_subscriber(
         .with_level(true);
     let base = tracing_subscriber::registry()
         .with(level_filter)
+        .with(tracing_subscriber::filter::filter_fn(metadata_filter))
         .with(fmt_layer);
 
     if service_name.is_empty() {
@@ -107,7 +119,21 @@ pub fn init_tracing_otel_with_logs_only_fallback(
     service_name: &str,
     tracer_name: &'static str,
 ) -> Option<TracerProviderGuard> {
-    match init_json_subscriber(log_level, service_name, tracer_name) {
+    init_tracing_otel_with_logs_only_fallback_and_filter(
+        log_level,
+        service_name,
+        tracer_name,
+        |_| true,
+    )
+}
+
+pub fn init_tracing_otel_with_logs_only_fallback_and_filter(
+    log_level: tracing::Level,
+    service_name: &str,
+    tracer_name: &'static str,
+    metadata_filter: fn(&tracing::Metadata<'_>) -> bool,
+) -> Option<TracerProviderGuard> {
+    match init_json_subscriber_with_filter(log_level, service_name, tracer_name, metadata_filter) {
         Ok(guard) => guard,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/transaction-sender/scripts/README.md
+++ b/coprocessor/fhevm-engine/transaction-sender/scripts/README.md
@@ -1,0 +1,43 @@
+# HTTP sender campaign helpers
+
+Run Rust build commands from `coprocessor/fhevm-engine` so rustup selects the
+pinned toolchain. Keep baseline worktrees in separate Cargo target directories.
+Do not infer an executable filename from an earlier build: Cargo's test binary
+hash changes with the toolchain and build configuration.
+
+Build the funded load driver:
+
+```sh
+cargo test --release --locked -p transaction-sender --test gw_patch_campaign --no-run
+```
+
+Set `GW_CAMPAIGN_EXECUTABLE` to the absolute executable path reported by that
+build, then run `python3 transaction-sender/scripts/run-gateway-soak.py`.
+`GW_ENV_FILE` defaults to `~/.config/fhevm-gw-test.env`. The runner uses account
+index 1 for zero-value transfers to itself, verifies chain 10900 and settled
+nonces, and requires the reservation unit test to pass before sending anything.
+It runs 20 seconds of warmup and 600 seconds measured at batch 10 × 2. The
+per-run limit defaults to 0.028 ETH (`GW_CAMPAIGN_SPEND_WEI`). Use a fresh
+`GW_CAMPAIGN_OUTPUT` directory for each run to preserve prior artifacts.
+The runner checks receipt outcomes and confirmed nonce progress after draining.
+
+The broader failure checks are ignored by default:
+
+```sh
+cargo test --release --locked -p transaction-sender --test gateway_retry_campaign_tests -- --ignored --test-threads=1
+cargo test --release --locked -p transaction-sender --test gateway_mixed_campaign_tests -- --ignored --nocapture
+```
+
+The mixed-workload test currently fails its fairness assertion. This is an
+intentional acceptance gate exposing an unresolved runtime limitation; do not
+change it to an expected panic or count recovery after fault removal as a pass.
+
+For the actual OTLP capture, build `gateway_otlp_campaign_tests` with `--no-run`,
+set `GW_OTLP_TEST_EXECUTABLE` to its absolute executable path, install Python
+`grpcio` in an isolated environment, and run `check-otlp-privacy.py`. It starts a
+local gRPC receiver, captures actual export payloads plus JSON stdout, requires
+positive-control markers, and rejects synthetic credential markers. It does not
+use the funded Gateway keys.
+
+Results and limitations are recorded in
+`docs/transaction-sender-validation-campaign-2026-09-11.md` at the repo root.

--- a/coprocessor/fhevm-engine/transaction-sender/scripts/README.md
+++ b/coprocessor/fhevm-engine/transaction-sender/scripts/README.md
@@ -28,9 +28,10 @@ cargo test --release --locked -p transaction-sender --test gateway_retry_campaig
 cargo test --release --locked -p transaction-sender --test gateway_mixed_campaign_tests -- --ignored --nocapture
 ```
 
-The mixed-workload test currently fails its fairness assertion. This is an
-intentional acceptance gate exposing an unresolved runtime limitation; do not
-change it to an expected panic or count recovery after fault removal as a pass.
+The mixed-workload test requires healthy proofs to drain while selective faults
+remain active, with new arrivals and two sender restarts. It also requires
+repeated attempts of deferred proofs, preservation of all fields except retry
+scheduling, and recovery after removing faults. It is not an expected panic.
 
 For the actual OTLP capture, build `gateway_otlp_campaign_tests` with `--no-run`,
 set `GW_OTLP_TEST_EXECUTABLE` to its absolute executable path, install Python

--- a/coprocessor/fhevm-engine/transaction-sender/scripts/check-otlp-privacy.py
+++ b/coprocessor/fhevm-engine/transaction-sender/scripts/check-otlp-privacy.py
@@ -1,0 +1,41 @@
+"""Capture real OTLP/gRPC exports from gateway_otlp_campaign_tests (requires grpcio)."""
+import concurrent.futures
+import os
+from pathlib import Path
+import subprocess
+import threading
+import grpc
+
+out = Path(os.environ.get('GW_CAMPAIGN_OUTPUT', '/tmp/fhevm-validation-locked'))
+out.mkdir(parents=True, exist_ok=True)
+packets = []
+lock = threading.Lock()
+
+def export(request, context):
+    with lock:
+        packets.append(request)
+    return b''  # Empty ExportTraceServiceResponse protobuf.
+
+server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=2))
+server.add_generic_rpc_handlers((grpc.method_handlers_generic_handler(
+    'opentelemetry.proto.collector.trace.v1.TraceService',
+    {'Export': grpc.unary_unary_rpc_method_handler(export,
+        request_deserializer=lambda x: x, response_serializer=lambda x: x)}),))
+port = server.add_insecure_port('127.0.0.1:0')
+server.start()
+try:
+    env = dict(os.environ, OTEL_EXPORTER_OTLP_ENDPOINT=f'http://127.0.0.1:{port}',
+               OTEL_BSP_SCHEDULE_DELAY='100')
+    result = subprocess.run([os.environ['GW_OTLP_TEST_EXECUTABLE'], '--ignored', '--nocapture'],
+                            env=env, capture_output=True, timeout=60)
+    logs = result.stdout + result.stderr
+    payload = b''.join(packets)
+    (out / 'otlp-json.log').write_bytes(logs)
+    (out / 'otlp-export.bin').write_bytes(payload)
+    assert result.returncode == 0, 'OTLP test binary failed'
+    for label, data in [('JSON', logs), ('OTLP', payload)]:
+        assert b'campaign_export_positive_marker' in data, f'{label} positive control absent'
+        assert b'SECRET' not in data, f'{label} leaked synthetic credential marker'
+    print(f'PASS: JSON and {len(packets)} OTLP exports contain positive control, no credential markers')
+finally:
+    server.stop(0).wait()

--- a/coprocessor/fhevm-engine/transaction-sender/scripts/run-gateway-soak.py
+++ b/coprocessor/fhevm-engine/transaction-sender/scripts/run-gateway-soak.py
@@ -1,0 +1,62 @@
+import os, pathlib, subprocess, json, urllib.request, re, hashlib
+ROOT=pathlib.Path(__file__).resolve().parents[4]
+OUT=pathlib.Path(os.environ.get('GW_CAMPAIGN_OUTPUT','/tmp/fhevm-validation-locked'))
+OUT.mkdir(parents=True,exist_ok=True)
+ENVFILE=pathlib.Path(os.environ.get('GW_ENV_FILE',str(pathlib.Path.home()/'.config/fhevm-gw-test.env')))
+url=None; addresses=[]
+for line in ENVFILE.read_text().splitlines():
+    if 'wss://' in line: url=line[line.index('wss://'):].strip().replace('wss://','https://',1)
+    if ':' in line:
+        k,v=line.split(':',1)
+        if k.strip().lower() in ['address','gw_address']: addresses.append(v.strip())
+def rpc(m,p):
+    try:
+        req=urllib.request.Request(url,json.dumps(dict(jsonrpc='2.0',id=1,method=m,params=p)).encode(),{'Content-Type':'application/json','User-Agent':'reqwest'})
+        return json.load(urllib.request.urlopen(req,timeout=15))['result']
+    except Exception: raise RuntimeError('Gateway preflight failed; raw diagnostic withheld') from None
+def snapshot():
+    rows=[]
+    for i,a in enumerate(addresses):
+        latest=int(rpc('eth_getTransactionCount',[a,'latest']),16)
+        pending=int(rpc('eth_getTransactionCount',[a,'pending']),16)
+        if latest!=pending: raise RuntimeError('Unmined account work: stop campaign')
+        rows.append(dict(account=i,latest=latest,pending=pending,balance_wei=int(rpc('eth_getBalance',[a,'latest']),16)))
+    return rows
+cases=[('http-soak-complete','https',10,2,1,1,20,600)]
+with (OUT/'performance-resume-status.log').open('w',buffering=1) as status:
+    try:
+        executable=os.environ.get('GW_CAMPAIGN_EXECUTABLE')
+        if not executable:
+            raise RuntimeError('Set GW_CAMPAIGN_EXECUTABLE to the built gw_patch_campaign test binary')
+        unit=subprocess.run([executable,'reservation_refunds_only_confirmed_costs','--exact'],capture_output=True)
+        if unit.returncode or b'1 passed; 0 failed' not in unit.stdout:
+            raise RuntimeError('Reservation accounting test did not pass exactly one test; stale executable?')
+        (OUT/'executable-sha256.txt').write_text(hashlib.sha256(pathlib.Path(executable).read_bytes()).hexdigest()+'\n')
+        if int(rpc('eth_chainId',[]),16)!=10900: raise RuntimeError('Unexpected chain')
+        initial=snapshot(); (OUT/'gateway-initial.json').write_text(json.dumps(initial,indent=2))
+        budget=int(os.environ.get('GW_CAMPAIGN_SPEND_WEI','28000000000000000'))
+        for name,transport,batch,ops,accounts,offset,warm,measure in cases:
+            before=snapshot(); spent=sum(max(0,a['balance_wei']-b['balance_wei']) for a,b in zip(initial,before))
+            available=min(budget-spent,30_000_000_000_000_000,min(row['balance_wei']*8//10 for row in before[offset:offset+accounts]))
+            if available<=0: raise RuntimeError('Campaign spend budget exhausted')
+            env=dict(os.environ,GW_ENV_FILE=str(ENVFILE),GW_RECIPIENT=addresses[offset],GW_TRANSPORT=transport,GW_SWEEP=str(batch),GW_OPS=str(ops),GW_ACCOUNTS=str(accounts),GW_ACCOUNT_OFFSET=str(offset),GW_WARMUP=str(warm),GW_MEASURE=str(measure),GW_MAX_ATTEMPTS='180000',GW_MAX_SPEND_WEI=str(available),GW_MAX_UNRESOLVED='320',GW_MAX_SECS=str(warm+measure+120))
+            status.write(f'START {name}, spent so far {spent/1e18:.8f} ETH\n')
+            with (OUT/(name+'.log')).open('w') as log:
+                proc=subprocess.run([executable,'--ignored','--nocapture'],env=env,stdout=log,stderr=log,timeout=warm+measure+180)
+            after=snapshot(); (OUT/(name+'-accounts.json')).write_text(json.dumps(after,indent=2))
+            status.write(f'END {name}: exit {proc.returncode}\n')
+            if proc.returncode: raise RuntimeError('Performance case failed; stop before next case')
+            # A passing load driver can still report RPC failures (useful for
+            # WSS comparisons). The HTTP soak has the stricter zero-error gate.
+            output=(OUT/(name+'.log')).read_text()
+            line=next((line for line in output.splitlines() if 'outcomes:' in line), '')
+            counts={key:int(value) for key,value in re.findall(r'(\w+)=(\d+)',line)}
+            required={'ok','reverted','send_timeout','nonce_low','nonce_high','already_known','null_response','underpriced','estimate_failed','other'}
+            if not required.issubset(counts) or counts.get('ok',0)<=0 or any(value for key,value in counts.items() if key!='ok'):
+                raise RuntimeError('HTTP soak had errors, incomplete accounting, or no successful receipts')
+            mined=sum(after[i]['latest']-before[i]['latest'] for i in range(offset,offset+accounts))
+            if mined!=counts['ok']: raise RuntimeError('Confirmed nonce progress differs from successful receipt count')
+        status.write('COMPLETE: all performance cases finished\n')
+    except Exception as error:
+        status.write('STOPPED: '+str(error)+'\n')
+        raise SystemExit(1)

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -48,7 +48,8 @@ struct Conf {
     ciphertext_commits_address: Address,
 
     #[arg(short, long)]
-    gateway_url: Url,
+    // Parse after clap: clap's value-parser errors echo the supplied value.
+    gateway_url: String,
 
     #[arg(short, long, value_enum, default_value = "private-key")]
     signer_type: SignerType,
@@ -202,15 +203,28 @@ fn get_provider(url: &Url, wallet: EthereumWallet) -> anyhow::Result<Provider> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), String> {
+    // Rust's default Result termination prints Debug, including anyhow source
+    // chains. Never hand it an unsanitized Gateway error.
+    run()
+        .await
+        .map_err(|error| transaction_sender::diagnostics::safe_error(error.as_ref()))
+}
+
+async fn run() -> anyhow::Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let conf = parse_args();
+    let gateway_url: Url = conf
+        .gateway_url
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Gateway URL must be a valid http:// or https:// URL"))?;
 
-    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback_and_filter(
         conf.log_level,
         &conf.service_name,
         "otlp-layer",
+        transaction_sender::diagnostics::gateway_tracing_filter,
     );
 
     let cancel_token = CancellationToken::new();
@@ -220,12 +234,12 @@ async fn main() -> anyhow::Result<()> {
     // WebSocket to HTTP; a leftover `wss://` value would otherwise be retried
     // forever, which looks like an unreachable Gateway rather than a
     // misconfiguration.
-    gateway_http_client(&conf.gateway_url).context("Gateway URL is not usable by this build")?;
+    gateway_http_client(&gateway_url).context("Gateway URL is not usable by this build")?;
 
     // Try to get the chain ID until cancelled.
     let chain_id = tokio::select! {
         chain_id = get_chain_id(
-            conf.gateway_url.clone(),
+            gateway_url.clone(),
             conf.graceful_shutdown_timeout,
         ) => chain_id?,
 
@@ -259,7 +273,7 @@ async fn main() -> anyhow::Result<()> {
     }
     let wallet = EthereumWallet::new(abstract_signer.clone());
 
-    let gateway_provider = get_provider(&conf.gateway_url, wallet.clone())?;
+    let gateway_provider = get_provider(&gateway_url, wallet.clone())?;
     info!(
         transport = "http",
         "Gateway provider configured; legacy provider-max-retries is ignored"
@@ -342,11 +356,7 @@ async fn main() -> anyhow::Result<()> {
     let transaction_sender_res = transaction_sender_fut.await;
     let http_server_res = http_server_fut.await;
 
-    info!(
-        transaction_sender_res = ?transaction_sender_res,
-        http_server_res = ?http_server_res,
-        "Transaction sender and HTTP health check server tasks have stopped"
-    );
+    info!("Transaction sender and HTTP health check server tasks have stopped");
 
     transaction_sender_res??;
     http_server_res??;

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -6,7 +6,7 @@ use alloy::{
     providers::fillers::{
         BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, WalletFiller,
     },
-    providers::{Identity, ProviderBuilder, RootProvider, WsConnect},
+    providers::{Identity, ProviderBuilder, RootProvider},
     signers::{aws::AwsSigner, local::PrivateKeySigner, Signer},
     transports::http::reqwest::Url,
 };
@@ -19,9 +19,10 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
 use transaction_sender::{
-    config::DEFAULT_GAS_LIMIT_OVERPROVISION_PERCENT, get_chain_id, http_server::HttpServer,
-    make_abstract_signer, metrics::spawn_gauge_update_routine, AbstractSigner, ConfigSettings,
-    FillersWithoutNonceManagement, NonceManagedProvider, TransactionSender,
+    config::DEFAULT_GAS_LIMIT_OVERPROVISION_PERCENT, gateway_http_client, get_chain_id,
+    http_server::HttpServer, make_abstract_signer, metrics::spawn_gauge_update_routine,
+    AbstractSigner, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
+    TransactionSender,
 };
 
 use fhevm_engine_common::{
@@ -107,9 +108,15 @@ struct Conf {
     #[arg(long, default_value_t = 30)]
     review_after_unlimited_retries: u16,
 
-    #[arg(long, default_value_t = u32::MAX)]
+    /// Legacy WebSocket reconnect setting. Accepted for compatibility and
+    /// unused on HTTP, where there is no persistent connection to retry.
+    #[arg(long, default_value_t = u32::MAX, hide = true)]
     provider_max_retries: u32,
 
+    /// Legacy WebSocket reconnect interval, accepted for compatibility and
+    /// unused. Note that the startup chain-ID probe paces itself with
+    /// `--graceful-shutdown-timeout`, which it did before this change too;
+    /// this flag never reached it.
     #[arg(long, default_value = "4s", value_parser = parse_duration)]
     provider_retry_interval: Duration,
 
@@ -181,52 +188,17 @@ type Provider = FillProvider<
     RootProvider,
 >;
 
-async fn get_provider(
-    conf: &Conf,
-    url: &Url,
-    name: &str,
-    wallet: EthereumWallet,
-    cancel_token: &CancellationToken,
-) -> anyhow::Result<Provider> {
-    loop {
-        if cancel_token.is_cancelled() {
-            info!(
-                "Cancellation requested before provider ({}) was created on startup, exiting",
-                name
-            );
-            anyhow::bail!(
-                "Cancellation requested before provider ({}) was created on startup, exiting",
-                name
-            );
-        }
-        match ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(wallet.clone())
-            .connect_ws(
-                // Note here that max_retries and retry_interval apply to sending requests, not to initial connection.
-                // We assume they are set to big values such that when they are reached, the following `BackendGone` error
-                // means we can't move on and we would exit the whole sender.
-                WsConnect::new(url.clone())
-                    .with_max_retries(conf.provider_max_retries)
-                    .with_retry_interval(conf.provider_retry_interval),
-            )
-            .await
-        {
-            Ok(provider) => {
-                info!(name, "Connected to chain");
-                return Ok(provider);
-            }
-            Err(e) => {
-                error!(
-                    name,
-                    error = %e,
-                    retry_interval = ?conf.provider_retry_interval,
-                    "Failed to connect to chain on startup, retrying"
-                );
-                tokio::time::sleep(conf.provider_retry_interval).await;
-            }
-        }
-    }
+/// Builds the Gateway provider.
+///
+/// The endpoint is now HTTP, so there is no connection to establish up front and
+/// nothing to reconnect: `reqwest` dials per request and pools the connection.
+/// `--provider-max-retries` and `--provider-retry-interval` were WebSocket
+/// reconnect settings; both are accepted for compatibility and unused.
+fn get_provider(url: &Url, wallet: EthereumWallet) -> anyhow::Result<Provider> {
+    Ok(ProviderBuilder::default()
+        .filler(FillersWithoutNonceManagement::default())
+        .wallet(wallet)
+        .connect_reqwest(gateway_http_client(url)?, url.clone()))
 }
 
 #[tokio::main]
@@ -244,12 +216,18 @@ async fn main() -> anyhow::Result<()> {
     let cancel_token = CancellationToken::new();
     install_signal_handlers(cancel_token.clone())?;
 
+    // Fail fast on a URL this build cannot use. The Gateway endpoint moved from
+    // WebSocket to HTTP; a leftover `wss://` value would otherwise be retried
+    // forever, which looks like an unreachable Gateway rather than a
+    // misconfiguration.
+    gateway_http_client(&conf.gateway_url).context("Gateway URL is not usable by this build")?;
+
     // Try to get the chain ID until cancelled.
     let chain_id = tokio::select! {
         chain_id = get_chain_id(
             conf.gateway_url.clone(),
             conf.graceful_shutdown_timeout,
-        ) => chain_id,
+        ) => chain_id?,
 
         _ = cancel_token.cancelled() => {
             info!("Cancellation requested before getting chain ID during startup, exiting");
@@ -281,20 +259,11 @@ async fn main() -> anyhow::Result<()> {
     }
     let wallet = EthereumWallet::new(abstract_signer.clone());
 
-    let Ok(gateway_provider) = get_provider(
-        &conf,
-        &conf.gateway_url,
-        "Gateway",
-        wallet.clone(),
-        &cancel_token,
-    )
-    .await
-    else {
-        info!(
-            "Cancellation requested before gateway chain provider was created on startup, exiting"
-        );
-        return Ok(());
-    };
+    let gateway_provider = get_provider(&conf.gateway_url, wallet.clone())?;
+    info!(
+        transport = "http",
+        "Gateway provider configured; legacy provider-max-retries is ignored"
+    );
     let gateway_provider =
         NonceManagedProvider::new(gateway_provider, Some(wallet.default_signer().address()));
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/diagnostics.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/diagnostics.rs
@@ -1,0 +1,161 @@
+//! Safe diagnostics for Gateway failures. Error values remain intact for retry
+//! classification; only their representation in logs, health output and DB
+//! columns is restricted. Upstream bodies/messages can echo credentials even
+//! without a URL, so redacting URL-shaped substrings alone is insufficient.
+use alloy::transports::{TransportError, TransportErrorKind};
+use std::error::Error;
+
+pub fn safe_error(error: &(dyn Error + 'static)) -> String {
+    let mut cause = Some(error);
+    while let Some(inner) = cause {
+        if let Some(rpc) = inner.downcast_ref::<TransportError>() {
+            return safe_rpc_error(rpc);
+        }
+        if inner.is::<alloy::transports::http::reqwest::Error>() {
+            return "Gateway HTTP request failed".into();
+        }
+        cause = inner.source();
+    }
+    // Non-Gateway errors (e.g. database availability) retain their diagnostics.
+    error.to_string()
+}
+
+pub fn safe_rpc_error(error: &TransportError) -> String {
+    match error {
+        TransportError::ErrorResp(payload) => {
+            // Preserve only known messages, never arbitrary response data.
+            let message = match payload.message.trim().to_ascii_lowercase().as_str() {
+                "context deadline exceeded" => "context deadline exceeded",
+                "service unavailable" => "service unavailable",
+                "temporarily unavailable" => "temporarily unavailable",
+                "too many requests" => "too many requests",
+                "nonce too low" => "nonce too low",
+                "nonce too high" => "nonce too high",
+                "replacement transaction underpriced" => "replacement transaction underpriced",
+                "insufficient funds" => "insufficient funds",
+                "execution reverted" => "execution reverted",
+                _ => "response details omitted",
+            };
+            format!("Gateway JSON-RPC error {}: {message}", payload.code)
+        }
+        TransportError::Transport(TransportErrorKind::HttpError(error)) => {
+            format!(
+                "Gateway HTTP error {} (response body omitted)",
+                error.status
+            )
+        }
+        TransportError::Transport(TransportErrorKind::BackendGone) => "Gateway backend gone".into(),
+        TransportError::Transport(TransportErrorKind::MissingBatchResponse(_)) => {
+            "Gateway missing batch response".into()
+        }
+        TransportError::Transport(TransportErrorKind::Custom(error)) => {
+            if error.to_string() == "eth_sendRawTransactionSync timeout" {
+                return "eth_sendRawTransactionSync timeout".into();
+            }
+            let mut cause: Option<&(dyn Error + 'static)> = Some(error.as_ref());
+            while let Some(inner) = cause {
+                if let Some(http) = inner.downcast_ref::<alloy::transports::http::reqwest::Error>()
+                {
+                    return if http.is_timeout() {
+                        "Gateway HTTP request timed out"
+                    } else if http.is_connect() {
+                        "Gateway HTTP connection failed"
+                    } else {
+                        "Gateway HTTP request failed"
+                    }
+                    .into();
+                }
+                cause = inner.source();
+            }
+            "Gateway transport error (details omitted)".into()
+        }
+        TransportError::DeserError { .. } => "Gateway invalid JSON response (body omitted)".into(),
+        TransportError::SerError(_) => "Gateway request serialization failed".into(),
+        TransportError::NullResp => "Gateway returned an unexpected null response".into(),
+        TransportError::LocalUsageError(_) => {
+            "Gateway local signing or request preparation failed".into()
+        }
+        _ => "Gateway RPC failure (details omitted)".into(),
+    }
+}
+
+/// These dependencies emit full RPC URLs, response bodies, or request details
+/// independently of our error formatting. Disable their events AND spans in
+/// both JSON logs and OTLP, including when the sender runs at DEBUG/TRACE.
+pub fn gateway_tracing_filter(metadata: &tracing::Metadata<'_>) -> bool {
+    let target = metadata.target();
+    ![
+        "alloy",
+        "reqwest",
+        "hyper",
+        "rustls",
+        "h2",
+        "tower_http",
+        "tungstenite",
+        "tokio_tungstenite",
+    ]
+    .iter()
+    .any(|prefix| target.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostics_omit_urls_bare_secrets_and_anyhow_contexts() {
+        let secret = "SECRET_PATH_QUERY_USER_PASSWORD";
+        let url = format!("https://user:{secret}@gateway.invalid/{secret}?key={secret}");
+        let errors = [
+            TransportErrorKind::http_error(400, format!("{url} bare secret: {secret}")),
+            TransportErrorKind::custom_str(&url),
+            TransportError::ErrorResp(
+                serde_json::from_value(serde_json::json!({
+                    "code": -32000, "message": url, "data": secret
+                }))
+                .unwrap(),
+            ),
+            TransportError::DeserError {
+                err: serde_json::from_str::<serde_json::Value>("<html>").unwrap_err(),
+                text: secret.into(),
+            },
+            TransportError::local_usage_str(secret),
+        ];
+        for error in errors {
+            let wrapped = anyhow::Error::new(error).context(format!("{url} {secret}"));
+            let diagnostic = safe_error(wrapped.as_ref());
+            assert!(!diagnostic.contains(secret));
+            assert!(!diagnostic.contains("gateway.invalid"));
+            assert!(!diagnostic.contains("https://"));
+            // Formatting must not replace the original typed error used by
+            // retry and contract-error classification.
+            assert!(wrapped.downcast_ref::<TransportError>().is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn actual_http_error_does_not_expose_credential_bearing_url() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!(
+            "http://USER_SECRET:PASS_SECRET@{}/PATH_SECRET?token=QUERY_SECRET",
+            listener.local_addr().unwrap()
+        );
+        drop(listener);
+        let client = alloy::transports::http::reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+        let error = client.get(url).send().await.unwrap_err();
+        assert!(error.is_connect());
+        let error = TransportErrorKind::custom(error);
+        assert_eq!(safe_rpc_error(&error), "Gateway HTTP connection failed");
+        assert!(error
+            .as_transport_err()
+            .unwrap()
+            .as_custom()
+            .unwrap()
+            .downcast_ref::<alloy::transports::http::reqwest::Error>()
+            .unwrap()
+            .is_connect());
+    }
+}

--- a/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod diagnostics;
 pub mod http_server;
 pub mod metrics;
 mod nonce_managed_provider;
@@ -86,8 +87,7 @@ impl HealthStatus {
 pub fn gateway_http_client(url: &Url) -> anyhow::Result<alloy::transports::http::reqwest::Client> {
     anyhow::ensure!(
         matches!(url.scheme(), "http" | "https"),
-        "transaction sender requires an http:// or https:// Gateway URL, got {}",
-        url.scheme()
+        "transaction sender requires an http:// or https:// Gateway URL"
     );
     Ok(alloy::transports::http::reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(4))
@@ -111,7 +111,7 @@ pub async fn get_chain_id(url: Url, retry_interval: Duration) -> anyhow::Result<
             }
             Err(e) => {
                 error!(
-                    error = %e,
+                    error = %diagnostics::safe_rpc_error(&e),
                     retry_interval = ?retry_interval,
                     "Failed to get chain ID from Gateway, retrying"
                 );

--- a/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use alloy::network::TxSigner;
 use alloy::providers::Provider;
 use alloy::providers::ProviderBuilder;
-use alloy::providers::WsConnect;
 use alloy::signers::Signature;
 use alloy::signers::Signer;
 use alloy::transports::http::reqwest::Url;
@@ -77,39 +76,41 @@ impl HealthStatus {
     }
 }
 
-// Gets the chain ID from the given WebSocket URL.
-// This is a utility function that will try to connect until it succeeds.
-pub async fn get_chain_id(ws_url: Url, retry_interval: Duration) -> u64 {
-    loop {
-        let provider = match ProviderBuilder::new()
-            .connect_ws(
-                WsConnect::new(ws_url.clone())
-                    .with_max_retries(1)
-                    .with_retry_interval(retry_interval),
-            )
-            .await
-        {
-            Ok(provider) => provider,
-            Err(e) => {
-                error!(
-                    ws_url = %ws_url,
-                    error = %e,
-                    retry_interval = ?retry_interval,
-                    "Failed to connect to Gateway, retrying"
-                );
-                tokio::time::sleep(retry_interval).await;
-                continue;
-            }
-        };
+/// Pooled HTTP client used for the Gateway RPCs.
+///
+/// The Gateway moved from a WebSocket endpoint to an HTTP one. Everything else
+/// about the sender is unchanged, so the policy here is deliberately plain:
+/// bounded connect and request times, no redirects, and no transport-level
+/// retry. A retried submission is indistinguishable from a duplicate one, and
+/// recovery already belongs to the operation retry loop.
+pub fn gateway_http_client(url: &Url) -> anyhow::Result<alloy::transports::http::reqwest::Client> {
+    anyhow::ensure!(
+        matches!(url.scheme(), "http" | "https"),
+        "transaction sender requires an http:// or https:// Gateway URL, got {}",
+        url.scheme()
+    );
+    Ok(alloy::transports::http::reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(4))
+        .timeout(Duration::from_secs(30))
+        .redirect(alloy::transports::http::reqwest::redirect::Policy::none())
+        .retry(alloy::transports::http::reqwest::retry::never())
+        .build()?)
+}
 
+// Gets the chain ID from the given Gateway URL.
+// This is a utility function that will try to connect until it succeeds.
+pub async fn get_chain_id(url: Url, retry_interval: Duration) -> anyhow::Result<u64> {
+    // A bad scheme is returned, not retried: it will never become good, and
+    // retrying one forever is the failure mode this replaces.
+    let provider = ProviderBuilder::new().connect_reqwest(gateway_http_client(&url)?, url);
+    loop {
         match provider.get_chain_id().await {
             Ok(chain_id) => {
                 tracing::info!(chain_id = chain_id, "Found chain ID");
-                return chain_id;
+                return Ok(chain_id);
             }
             Err(e) => {
                 error!(
-                    ws_url = %ws_url,
                     error = %e,
                     retry_interval = ?retry_interval,
                     "Failed to get chain ID from Gateway, retrying"

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -87,13 +87,13 @@ where
                 {
                     ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER.inc();
                     warn!(
-                        error = %e,
+                        error = %crate::diagnostics::safe_rpc_error(&e),
                         handle = h,
                         "Transaction sending failed with unlimited retry error"
                     );
                     self.increment_txn_unlimited_retries_count(
                         handle,
-                        &e.to_string(),
+                        &crate::diagnostics::safe_rpc_error(&e),
                         current_unlimited_retries_count,
                     )
                     .await?;
@@ -116,13 +116,13 @@ where
                 }
                 ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER.inc();
                 warn!(
-                    error = %e,
+                    error = %crate::diagnostics::safe_rpc_error(&e),
                     handle = h,
                     "Transaction sending failed"
                 );
                 self.increment_txn_limited_retries_count(
                     handle,
-                    &e.to_string(),
+                    &crate::diagnostics::safe_rpc_error(&e),
                     current_limited_retries_count,
                 )
                 .await?;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/common.rs
@@ -7,6 +7,58 @@ use fhevm_gateway_bindings::gateway_config_checks::GatewayConfigChecks::GatewayC
 use std::convert::TryInto;
 use thiserror::Error;
 
+/// Infrastructure failures do not say whether a proof is invalid. Keep them
+/// outside its terminal retry budget, but return the error to the operation
+/// loop so its normal backoff (or BackendGone shutdown) still applies.
+pub(crate) fn is_transient_gateway_error(err: &RpcError<TransportErrorKind>) -> bool {
+    match err {
+        RpcError::Transport(TransportErrorKind::BackendGone)
+        | RpcError::Transport(TransportErrorKind::MissingBatchResponse(_)) => true,
+        RpcError::Transport(TransportErrorKind::HttpError(err)) => {
+            // HTTP 500 deliberately preserves work too: the status alone does
+            // not establish a terminal proof failure. A persistent application
+            // defect returning 500 can therefore keep work retrying indefinitely.
+            matches!(err.status, 408 | 429 | 500 | 502 | 503 | 504)
+        }
+        RpcError::Transport(TransportErrorKind::Custom(err)) => {
+            // This exact error is emitted by NonceManagedProvider's local send
+            // deadline. Do not classify arbitrary custom errors by substring.
+            if err.to_string() == "eth_sendRawTransactionSync timeout" {
+                return true;
+            }
+            let mut cause: Option<&(dyn std::error::Error + 'static)> = Some(err.as_ref());
+            while let Some(inner) = cause {
+                if let Some(http) = inner.downcast_ref::<alloy::transports::http::reqwest::Error>()
+                {
+                    return http.is_connect()
+                        || http.is_timeout()
+                        || http.is_request()
+                        || http.is_body();
+                }
+                cause = inner.source();
+            }
+            false
+        }
+        RpcError::ErrorResp(err) => {
+            // Do not interpret contract reverts, nonce errors, or generic
+            // internal errors as infrastructure failures. Match explicit
+            // unavailability messages on the Gateway's server-error codes.
+            // This is narrower than Alloy's provider-specific rate-limit policy:
+            // e.g. -32005 is not covered and retains limited-retry accounting.
+            err.code == 429
+                || (matches!(err.code, -32000 | -32603)
+                    && matches!(
+                        err.message.trim().to_ascii_lowercase().as_str(),
+                        "context deadline exceeded"
+                            | "service unavailable"
+                            | "temporarily unavailable"
+                            | "too many requests"
+                    ))
+        }
+        _ => false,
+    }
+}
+
 pub(crate) fn try_into_array<const SIZE: usize>(vec: Vec<u8>) -> Result<[u8; SIZE]> {
     if vec.len() != SIZE {
         return Err(anyhow!(
@@ -74,4 +126,114 @@ pub(crate) fn try_extract_non_retryable_config_error(
             ),
             _ => None,
         })
+}
+
+#[cfg(test)]
+mod transient_gateway_tests {
+    use super::*;
+
+    #[test]
+    fn http_status_policy_excludes_permanent_errors() {
+        for status in [408, 429, 500, 502, 503, 504] {
+            assert!(
+                is_transient_gateway_error(&TransportErrorKind::http_error(status, String::new())),
+                "HTTP {status}"
+            );
+        }
+        for status in [400, 401, 403, 404, 405, 501, 505] {
+            assert!(
+                !is_transient_gateway_error(&TransportErrorKind::http_error(
+                    status,
+                    "context deadline exceeded".into()
+                )),
+                "HTTP {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn rpc_policy_does_not_hide_transaction_or_contract_errors() {
+        for (code, message, expected) in [
+            (-32000, "context deadline exceeded", true),
+            (-32603, "context deadline exceeded", true),
+            (-32000, "service unavailable", true),
+            (-32603, "temporarily unavailable", true),
+            (-32000, "too many requests", true),
+            (429, "rate limited", true),
+            (-32603, "internal error", false),
+            (-32000, "nonce too low", false),
+            (-32000, "nonce too high", false),
+            (-32000, "replacement transaction underpriced", false),
+            (-32000, "insufficient funds", false),
+            (
+                -32000,
+                "execution reverted: context deadline exceeded",
+                false,
+            ),
+            (3, "context deadline exceeded", false),
+            (-32601, "method not found", false),
+            (-32602, "invalid params", false),
+        ] {
+            let error = RpcError::ErrorResp(
+                serde_json::from_value(serde_json::json!({
+                    "code": code, "message": message,
+                }))
+                .unwrap(),
+            );
+            assert_eq!(
+                is_transient_gateway_error(&error),
+                expected,
+                "{code}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_errors_are_not_all_transient() {
+        assert!(is_transient_gateway_error(&TransportErrorKind::custom_str(
+            "eth_sendRawTransactionSync timeout"
+        )));
+        assert!(is_transient_gateway_error(
+            &TransportErrorKind::backend_gone()
+        ));
+        assert!(!is_transient_gateway_error(
+            &TransportErrorKind::custom_str("signer unavailable")
+        ));
+        assert!(!is_transient_gateway_error(
+            &TransportErrorKind::custom_str("context deadline exceeded")
+        ));
+    }
+
+    #[tokio::test]
+    async fn actual_reqwest_connection_failure_and_timeout_are_transient() {
+        use alloy::transports::http::reqwest;
+        use std::time::Duration;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        // TCP connects, but no HTTP response arrives.
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let error = client.get(&url).send().await.unwrap_err();
+        assert!(error.is_timeout());
+        assert!(is_transient_gateway_error(&TransportErrorKind::custom(
+            error
+        )));
+
+        drop(listener);
+        let error = client.get(&url).send().await.unwrap_err();
+        assert!(error.is_connect());
+        assert!(is_transient_gateway_error(&TransportErrorKind::custom(
+            error
+        )));
+
+        let error = client.get("not a URL").send().await.unwrap_err();
+        assert!(error.is_builder());
+        assert!(!is_transient_gateway_error(&TransportErrorKind::custom(
+            error
+        )));
+    }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/common.rs
@@ -12,6 +12,10 @@ use thiserror::Error;
 /// loop so its normal backoff (or BackendGone shutdown) still applies.
 pub(crate) fn is_transient_gateway_error(err: &RpcError<TransportErrorKind>) -> bool {
     match err {
+        // HTML maintenance pages, empty bodies and malformed JSON provide no
+        // evidence that the proof is invalid. Preserve work with scheduling
+        // delay even when an intermediary returned HTTP 200.
+        RpcError::DeserError { .. } => true,
         RpcError::Transport(TransportErrorKind::BackendGone)
         | RpcError::Transport(TransportErrorKind::MissingBatchResponse(_)) => true,
         RpcError::Transport(TransportErrorKind::HttpError(err)) => {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -198,8 +198,15 @@ where
                         error = %crate::diagnostics::safe_rpc_error(&e),
                         "Gateway temporarily unavailable; preserving proof retry budget"
                     );
-                    // Preserve eligibility, including at max_retries - 1.
-                    // Returning Err is essential: it invokes operation backoff.
+                    // Keep the finite budget and last error intact, but persist
+                    // the attempt so a failing batch cannot monopolize selection.
+                    sqlx::query!(
+                        "UPDATE verify_proofs SET last_retry_at = NOW() WHERE zk_proof_id = $1",
+                        txn_request.0
+                    )
+                    .execute(&self.db_pool)
+                    .await?;
+                    // Retain operation backoff and BackendGone shutdown handling.
                     return Err(anyhow::Error::new(e));
                 } else {
                     VERIFY_PROOF_FAIL_COUNTER.inc();
@@ -299,10 +306,12 @@ where
             "SELECT zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count, extra_data, transaction_id
              FROM verify_proofs
              WHERE verified IS NOT NULL AND retry_count < $1
-             ORDER BY zk_proof_id
+               AND (last_retry_at IS NULL OR last_retry_at <= NOW() - make_interval(secs => $3))
+             ORDER BY COALESCE(last_retry_at, created_at), zk_proof_id
              LIMIT $2",
             self.conf.verify_proof_resp_max_retries as i64,
-            self.conf.verify_proof_resp_batch_limit as i64
+            self.conf.verify_proof_resp_batch_limit as i64,
+            f64::from(self.conf.error_sleep_max_secs.max(1))
         )
         .fetch_all(&self.db_pool)
         .await?;
@@ -430,8 +439,19 @@ where
                     .await
             });
         }
+        // Drain mixed batches before returning an error. Dropping the JoinSet
+        // would cancel healthy submissions, possibly after nonce allocation.
+        let mut first_error = None;
         while let Some(res) = join_set.join_next().await {
-            res??;
+            if let Err(error) = res.map_err(anyhow::Error::from).and_then(|result| result) {
+                // Keep fatal transport shutdown even if another task failed first.
+                if first_error.is_none() || crate::is_backend_gone(&error) {
+                    first_error = Some(error);
+                }
+            }
+        }
+        if let Some(error) = first_error {
+            return Err(error);
         }
         Ok(maybe_has_more_work)
     }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -1,4 +1,4 @@
-use super::common::try_extract_non_retryable_config_error;
+use super::common::{is_transient_gateway_error, try_extract_non_retryable_config_error};
 use super::TransactionOperation;
 use crate::metrics::{VERIFY_PROOF_FAIL_COUNTER, VERIFY_PROOF_SUCCESS_COUNTER};
 use crate::nonce_managed_provider::NonceManagedProvider;
@@ -191,6 +191,16 @@ where
                     )
                     .await?;
                     return Ok(());
+                } else if is_transient_gateway_error(&e) {
+                    VERIFY_PROOF_FAIL_COUNTER.inc();
+                    warn!(
+                        zk_proof_id = txn_request.0,
+                        error = %e,
+                        "Gateway temporarily unavailable; preserving proof retry budget"
+                    );
+                    // Preserve eligibility, including at max_retries - 1.
+                    // Returning Err is essential: it invokes operation backoff.
+                    return Err(anyhow::Error::new(e));
                 } else {
                     VERIFY_PROOF_FAIL_COUNTER.inc();
                     error!(

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -195,7 +195,7 @@ where
                     VERIFY_PROOF_FAIL_COUNTER.inc();
                     warn!(
                         zk_proof_id = txn_request.0,
-                        error = %e,
+                        error = %crate::diagnostics::safe_rpc_error(&e),
                         "Gateway temporarily unavailable; preserving proof retry budget"
                     );
                     // Preserve eligibility, including at max_retries - 1.
@@ -205,13 +205,13 @@ where
                     VERIFY_PROOF_FAIL_COUNTER.inc();
                     error!(
                         zk_proof_id = txn_request.0,
-                        error = %e,
+                        error = %crate::diagnostics::safe_rpc_error(&e),
                         "Transaction sending failed"
                     );
                     self.update_retry_count_by_proof_id(
                         txn_request.0,
                         current_retry_count,
-                        &e.to_string(),
+                        &crate::diagnostics::safe_rpc_error(&e),
                     )
                     .await?;
                     return Err(anyhow::Error::new(e));

--- a/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -102,7 +102,7 @@ where
                                 if is_backend_gone(&e) {
                                     error!(
                                         channel = op_channel,
-                                        error = %e,
+                                        error = %crate::diagnostics::safe_error(e.as_ref()),
                                         "Backend gone error, stopping operation and signaling other operations to stop"
                                     );
                                     token.cancel();
@@ -110,7 +110,7 @@ where
                                 }
                                 error!(
                                     channel = op_channel,
-                                    error = %e,
+                                    error = %crate::diagnostics::safe_error(e.as_ref()),
                                     sleep_duration = sleep_duration,
                                     "Operation error, retrying after sleep"
                                 );
@@ -193,11 +193,11 @@ where
                             info!("An operation stopped gracefully");
                         }
                         Some(Ok(Err(e))) => {
-                            error!(error = %e, "An operation returned an error");
+                            error!(error = %crate::diagnostics::safe_error(e.as_ref()), "An operation returned an error");
                             break Err(e);
                         }
                         Some(Err(e)) => {
-                            error!(error = %e, "Join failed with an error");
+                            error!(error = %crate::diagnostics::safe_error(&e), "Join failed with an error");
                             break Err(e.into());
                         }
                         None => {
@@ -247,7 +247,10 @@ where
                 blockchain_connected = true;
             }
             Ok(Err(e)) => {
-                error_details.push(format!("Blockchain connection error: {}", e));
+                error_details.push(format!(
+                    "Blockchain connection error: {}",
+                    crate::diagnostics::safe_rpc_error(&e)
+                ));
             }
             Err(_) => {
                 error_details.push("Blockchain connection timeout".to_string());

--- a/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use alloy::network::TxSigner;
-use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::providers::Provider;
 use alloy::signers::local::PrivateKeySigner;
 use common::{is_coprocessor_config_error, CiphertextCommits, TestEnvironment};
 
@@ -12,10 +12,7 @@ use serial_test::serial;
 use std::time::Duration;
 use test_harness::db_utils::{insert_ciphertext_digest, insert_random_keys_and_host_chain};
 use tokio::time::sleep;
-use transaction_sender::{
-    is_backend_gone, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
-    TransactionSender,
-};
+use transaction_sender::{ConfigSettings, NonceManagedProvider, TransactionSender};
 
 #[rstest]
 #[case::private_key(SignerType::PrivateKey)]
@@ -26,16 +23,9 @@ async fn add_ciphertext_digests(#[case] signer_type: SignerType) -> anyhow::Resu
     use test_harness::db_utils::insert_ciphertext_digest;
 
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -122,16 +112,9 @@ async fn add_ciphertext_digests(#[case] signer_type: SignerType) -> anyhow::Resu
 #[serial(db)]
 async fn ciphertext_digest_already_added(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -216,16 +199,9 @@ async fn ciphertext_digest_already_added(#[case] signer_type: SignerType) -> any
 #[serial(db)]
 async fn recover_from_transport_error(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let mut env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -296,12 +272,26 @@ async fn recover_from_transport_error(#[case] signer_type: SignerType) -> anyhow
     Ok(())
 }
 
+/// Over WebSocket, a Gateway that goes away produced `BackendGone`, which the
+/// sender treats as fatal: it cancels every operation and exits, so the
+/// supervisor restarts it and nothing burns retries against a dead endpoint.
+///
+/// Over HTTP there is no such signal. `reqwest` reports a connection error,
+/// `TransportErrorKind::Custom`, and `is_retry_err()` is false for it — only a
+/// 429 or an explicitly unavailable status counts. So `is_backend_gone` never
+/// matches and **the sender does not stop**. This test pins that changed
+/// behaviour rather than the old one, because the old assertion now hangs
+/// forever.
+///
+/// See `gateway_outage_burns_verify_proof_retries` in the verify-proof suite
+/// for what that costs.
 #[rstest]
 #[case::private_key(SignerType::PrivateKey)]
-#[case::aws_kms(SignerType::AwsKms)]
 #[tokio::test]
 #[serial(db)]
-async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result<()> {
+async fn gateway_outage_no_longer_stops_the_sender_over_http(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
     let conf = ConfigSettings {
         add_ciphertexts_max_retries: 2,
         graceful_shutdown_timeout: Duration::from_secs(2),
@@ -312,26 +302,9 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
     let mut env =
         TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
             .await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(
-            // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
-            WsConnect::new(env.ws_endpoint_url())
-                .with_max_retries(1)
-                .with_retry_interval(Duration::from_millis(200)),
-        )
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(
-                // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
-                WsConnect::new(env.ws_endpoint_url())
-                    .with_max_retries(1)
-                    .with_retry_interval(Duration::from_millis(200)),
-            )
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -351,13 +324,12 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
     .await?;
 
     let run_handle = tokio::spawn(async move { txn_sender.run().await });
-
     let (host_chain_id, key_id) = insert_random_keys_and_host_chain(&env.db_pool).await?;
+    let _ = provider.get_transaction_count(env.signer.address()).await?;
 
-    // Simulate a transport error by stopping the anvil instance.
+    // Take the Gateway away for good.
     env.drop_anvil();
 
-    // Insert a ciphertext digest into the database.
     let handle = random::<[u8; 32]>();
     insert_ciphertext_digest(
         &env.db_pool,
@@ -366,10 +338,9 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
         &handle,
         &random::<[u8; 32]>(),
         &random::<[u8; 32]>(),
-        0,
+        1,
     )
     .await?;
-
     sqlx::query!(
         "
         SELECT pg_notify($1, '')",
@@ -378,9 +349,11 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
     .execute(&env.db_pool)
     .await?;
 
-    // Make sure the digest is not sent, the retry count is 0 and the unlimited retry count is 1.
-    loop {
-        let rows = sqlx::query!(
+    // The digest keeps failing and is retried; the sender stays up.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut saw_a_retry = false;
+    while tokio::time::Instant::now() < deadline {
+        let row = sqlx::query!(
             "SELECT txn_is_sent, txn_limited_retries_count, txn_unlimited_retries_count
              FROM ciphertext_digest
              WHERE handle = $1",
@@ -388,18 +361,28 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
         )
         .fetch_one(&env.db_pool)
         .await?;
-        if !rows.txn_is_sent
-            && rows.txn_limited_retries_count == 0
-            && rows.txn_unlimited_retries_count == 1
+        if !row.txn_is_sent
+            && (row.txn_limited_retries_count > 0 || row.txn_unlimited_retries_count > 0)
         {
+            saw_a_retry = true;
             break;
         }
-        sleep(Duration::from_millis(500)).await;
+        sleep(Duration::from_millis(250)).await;
     }
+    assert!(
+        saw_a_retry,
+        "the digest should have been attempted and failed"
+    );
 
-    // Expect that the sender will stop on its own due to BackendGone.
-    let err = run_handle.await?.err().unwrap();
-    assert!(is_backend_gone(&err));
+    assert!(
+        !run_handle.is_finished(),
+        "over HTTP the sender must be observed NOT stopping on a dead Gateway; \
+if this now fails, the outage signal has been restored and the assertion \
+should go back to expecting BackendGone"
+    );
+
+    env.cancel_token.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), run_handle).await;
     Ok(())
 }
 
@@ -423,11 +406,7 @@ async fn retry_mechanism(#[case] signer_type: SignerType) -> anyhow::Result<()> 
     // Create a provider with a random wallet without funds.
     let wallet: EthereumWallet = PrivateKeySigner::random().into();
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(wallet)
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner_with(wallet)?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -519,16 +498,9 @@ async fn retry_on_aws_kms_error(#[case] signer_type: SignerType) -> anyhow::Resu
     let mut env =
         TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
             .await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -615,16 +587,9 @@ async fn stop_retrying_add_ciphertext_on_gw_config_error(
     let env =
         TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
             .await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
 

--- a/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
@@ -19,7 +19,10 @@ use test_harness::localstack::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
-use transaction_sender::{get_chain_id, make_abstract_signer, AbstractSigner, ConfigSettings};
+use transaction_sender::{
+    gateway_http_client, get_chain_id, make_abstract_signer, AbstractSigner, ConfigSettings,
+    FillersWithoutNonceManagement, NonceManagedProvider,
+};
 
 sol!(
     #[sol(rpc)]
@@ -105,7 +108,7 @@ impl TestEnvironment {
 
         let anvil = Self::new_anvil()?;
         let chain_id =
-            get_chain_id(anvil.ws_endpoint_url(), std::time::Duration::from_secs(1)).await;
+            get_chain_id(anvil.endpoint_url(), std::time::Duration::from_secs(1)).await?;
         let abstract_signer;
         let localstack;
         match signer_type {
@@ -152,6 +155,53 @@ impl TestEnvironment {
 
     pub fn ws_endpoint_url(&self) -> Url {
         self.anvil.as_ref().unwrap().ws_endpoint_url()
+    }
+
+    /// The Gateway URL under test. The endpoint moved from WebSocket to HTTP,
+    /// so this is what the sender and its tests now use.
+    pub fn http_endpoint_url(&self) -> Url {
+        self.anvil.as_ref().unwrap().endpoint_url()
+    }
+
+    /// A provider built exactly the way the binary builds one: the pooled
+    /// client from `gateway_http_client`, attached with `connect_reqwest`.
+    pub fn http_provider(&self) -> anyhow::Result<alloy::providers::DynProvider> {
+        use alloy::providers::Provider as _;
+        let url = self.http_endpoint_url();
+        Ok(alloy::providers::ProviderBuilder::new()
+            .wallet(self.wallet.clone())
+            .connect_reqwest(gateway_http_client(&url)?, url)
+            .erased())
+    }
+
+    /// The inner provider the sender wraps: no nonce management in the filler
+    /// stack, because `NonceManagedProvider` supplies the nonce.
+    pub fn http_sender_inner(&self) -> anyhow::Result<alloy::providers::DynProvider> {
+        self.http_sender_inner_with(self.wallet.clone())
+    }
+
+    /// Same, for a caller-supplied wallet (an unfunded one, for instance).
+    pub fn http_sender_inner_with(
+        &self,
+        wallet: alloy::network::EthereumWallet,
+    ) -> anyhow::Result<alloy::providers::DynProvider> {
+        use alloy::providers::Provider as _;
+        let url = self.http_endpoint_url();
+        Ok(alloy::providers::ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(wallet)
+            .connect_reqwest(gateway_http_client(&url)?, url)
+            .erased())
+    }
+
+    /// The sender's provider, nonce management included.
+    pub fn http_sender_provider(
+        &self,
+    ) -> anyhow::Result<NonceManagedProvider<alloy::providers::DynProvider>> {
+        Ok(NonceManagedProvider::new(
+            self.http_sender_inner()?,
+            Some(self.wallet.default_signer().address()),
+        ))
     }
 
     pub fn recreate_anvil(&mut self) -> anyhow::Result<()> {

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_diagnostics_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_diagnostics_tests.rs
@@ -134,7 +134,8 @@ async fn gateway_credentials_stay_out_of_logs_health_and_database() -> anyhow::R
         (
             200,
             format!("<html>{echoed}</html>"),
-            "invalid JSON response",
+            // Unreadable responses preserve the prior proof error and budget.
+            "JSON-RPC error -32000",
             "invalid JSON response",
         ),
     ];

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_diagnostics_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_diagnostics_tests.rs
@@ -1,0 +1,215 @@
+mod common;
+mod support;
+
+use alloy::providers::ProviderBuilder;
+use common::{CiphertextCommits, InputVerification, SignerType, TestEnvironment};
+use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use support::{Fault, FaultProxy};
+use test_harness::db_utils::{insert_ciphertext_digest, insert_random_keys_and_host_chain};
+use tracing_subscriber::prelude::*;
+use transaction_sender::{
+    diagnostics::gateway_tracing_filter, gateway_http_client, get_chain_id, ConfigSettings,
+    FillersWithoutNonceManagement, NonceManagedProvider, TransactionSender,
+};
+
+#[derive(Clone, Default)]
+struct Logs(Arc<Mutex<Vec<u8>>>);
+impl Write for Logs {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Logs {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self {
+        self.clone()
+    }
+}
+
+/// Capture TRACE-level logs while exercising actual providers and DB writes.
+/// A Gateway can echo a bare token as well as its full URL, including in a
+/// malformed response; both must be absent from every diagnostic sink.
+#[tokio::test]
+async fn gateway_credentials_stay_out_of_logs_health_and_database() -> anyhow::Result<()> {
+    let logs = Logs::default();
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::filter::filter_fn(
+            gateway_tracing_filter,
+        ))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(logs.clone()),
+        )
+        .try_init()?;
+    let conf = ConfigSettings {
+        verify_proof_resp_max_retries: 50,
+        verify_proof_remove_after_max_retries: false,
+        add_ciphertexts_max_retries: 50,
+        error_sleep_initial_secs: 1,
+        error_sleep_max_secs: 1,
+        graceful_shutdown_timeout: Duration::from_secs(5),
+        ..Default::default()
+    };
+    let env = TestEnvironment::new_with_config(SignerType::PrivateKey, conf, false).await?;
+    let deploy = env.http_provider()?;
+    let input = InputVerification::deploy(&deploy, false, false, false, false).await?;
+    let commits = CiphertextCommits::deploy(&deploy, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+    let mut url = proxy.url();
+    url.set_username("GW_USER_SECRET").unwrap();
+    url.set_password(Some("GW_PASSWORD_SECRET")).unwrap();
+    url.set_path("/GW_PATH_SECRET");
+    url.set_query(Some("token=GW_QUERY_SECRET"));
+    let inner = ProviderBuilder::default()
+        .filler(FillersWithoutNonceManagement::default())
+        .wallet(env.wallet.clone())
+        .connect_reqwest(gateway_http_client(&url)?, url.clone());
+    let provider = NonceManagedProvider::new(inner, Some(env.wallet.default_signer().address()));
+    let sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input.address(),
+        *commits.address(),
+        env.signer.clone(),
+        provider,
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+    let (host_chain_id, key_id) = insert_random_keys_and_host_chain(&env.db_pool).await?;
+    insert_ciphertext_digest(
+        &env.db_pool,
+        host_chain_id,
+        key_id,
+        &[1u8; 32],
+        &[2u8; 32],
+        &[3u8; 32],
+        1,
+    )
+    .await?;
+    sqlx::query(
+        "INSERT INTO verify_proofs
+        (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+        VALUES (123, 42, $1, $2, $3, true)",
+    )
+    .bind(env.contract_address.to_string())
+    .bind(env.user_address.to_string())
+    .bind(vec![1u8; 64])
+    .execute(&env.db_pool)
+    .await?;
+
+    let echoed = format!("upstream URL {url}, bare token GW_BARE_SECRET");
+    proxy.set_fault(
+        "eth_estimateGas",
+        Fault::RawResponse {
+            status: 400,
+            body: echoed.clone(),
+        },
+        None,
+    );
+    let run_sender = sender.clone();
+    let run = tokio::spawn(async move { run_sender.run().await });
+    let cases = [
+        (400, echoed.clone(), "HTTP error 400", "HTTP error 400"),
+        // Proof budget is preserved, but add-ciphertext's existing unlimited
+        // bucket still writes an error. Cover that DB sink too.
+        (429, echoed.clone(), "HTTP error 400", "HTTP error 429"),
+        (
+            200,
+            serde_json::json!({"jsonrpc":"2.0", "id":0,
+            "error":{"code":-32000,"message":echoed,"data":"GW_BARE_SECRET"}})
+            .to_string(),
+            "JSON-RPC error -32000",
+            "JSON-RPC error -32000",
+        ),
+        (
+            200,
+            format!("<html>{echoed}</html>"),
+            "invalid JSON response",
+            "invalid JSON response",
+        ),
+    ];
+    for (status, body, proof_expected, ciphertext_expected) in cases {
+        // JSON-RPC responses must echo the actual request ID (see proxy).
+        proxy.set_fault("eth_estimateGas", Fault::RawResponse { status, body }, None);
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                let proof: Option<String> = sqlx::query_scalar(
+                    "SELECT last_error FROM verify_proofs WHERE zk_proof_id = 123",
+                )
+                .fetch_one(&env.db_pool)
+                .await?;
+                let ciphertext: Option<String> =
+                    sqlx::query_scalar("SELECT txn_last_error FROM ciphertext_digest LIMIT 1")
+                        .fetch_one(&env.db_pool)
+                        .await?;
+                for value in [&proof, &ciphertext].into_iter().flatten() {
+                    assert!(!value.contains("SECRET"), "credential leaked into DB error");
+                    assert!(
+                        !value.contains(url.as_str()),
+                        "Gateway URL leaked into DB error"
+                    );
+                }
+                if proof.as_deref().is_some_and(|v| v.contains(proof_expected))
+                    && ciphertext
+                        .as_deref()
+                        .is_some_and(|v| v.contains(ciphertext_expected))
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            anyhow::Ok(())
+        })
+        .await??;
+    }
+
+    for method in ["eth_blockNumber", "eth_chainId"] {
+        proxy.set_fault(
+            method,
+            Fault::RawResponse {
+                status: 400,
+                body: echoed.clone(),
+            },
+            None,
+        );
+    }
+    let health = sender.health_check().await;
+    assert!(!health.healthy);
+    assert!(!health.details.unwrap().contains("SECRET"));
+    let calls = proxy.calls("eth_chainId");
+    assert!(tokio::time::timeout(
+        Duration::from_millis(300),
+        get_chain_id(url, Duration::from_secs(1))
+    )
+    .await
+    .is_err());
+    assert!(
+        proxy.calls("eth_chainId") > calls,
+        "startup probe must encounter an error"
+    );
+    env.cancel_token.cancel();
+    tokio::time::timeout(Duration::from_secs(10), run).await???;
+    // TLS handshake diagnostics can expose endpoint names via ClientHello.
+    tracing::trace!(target: "rustls::client::hs", "GW_TLS_SECRET");
+    tracing::info!("gateway diagnostics regression completed");
+    let output = String::from_utf8(logs.0.lock().unwrap().clone())?;
+    assert!(
+        output.contains("gateway diagnostics regression completed"),
+        "log capture must be active"
+    );
+    assert!(
+        !output.contains("SECRET"),
+        "credential leaked into logs or span fields"
+    );
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_mixed_campaign_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_mixed_campaign_tests.rs
@@ -1,0 +1,174 @@
+mod common;
+mod support;
+
+use alloy::providers::ProviderBuilder;
+use common::{CiphertextCommits, InputVerification, SignerType, TestEnvironment};
+use std::time::Duration;
+use support::FaultProxy;
+use test_harness::db_utils::{insert_ciphertext_digest, insert_random_keys_and_host_chain};
+use transaction_sender::{
+    gateway_http_client, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
+    TransactionSender,
+};
+
+#[tokio::test]
+#[ignore = "extended validation campaign"]
+async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        verify_proof_resp_batch_limit: 10,
+        add_ciphertexts_batch_limit: 10,
+        verify_proof_resp_max_retries: 15,
+        verify_proof_remove_after_max_retries: true,
+        graceful_shutdown_timeout: Duration::from_secs(6),
+        ..Default::default()
+    };
+    let mut env = TestEnvironment::new_with_config(SignerType::PrivateKey, conf, false).await?;
+    let deploy = env.http_provider()?;
+    let input = InputVerification::deploy(&deploy, false, false, false, false).await?;
+    let commits = CiphertextCommits::deploy(&deploy, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+    proxy.set_early_proof_fault(10);
+    sqlx::raw_sql(
+        "CREATE TABLE mixed_audit (old_row jsonb, new_row jsonb);
+        CREATE FUNCTION audit_mixed() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN INSERT INTO mixed_audit VALUES (to_jsonb(OLD), to_jsonb(NEW)); RETURN NULL; END $$;
+        CREATE TRIGGER mixed_audit AFTER UPDATE OR DELETE ON verify_proofs
+        FOR EACH ROW EXECUTE FUNCTION audit_mixed();",
+    )
+    .execute(&env.db_pool)
+    .await?;
+    let (host, key) = insert_random_keys_and_host_chain(&env.db_pool).await?;
+    let mut next_id = 1i64;
+    let mut later_completed = Vec::new();
+    for cycle in 0..3 {
+        // More than two proof batches initially; new work arrives on each restart.
+        let count = if cycle == 0 { 30 } else { 10 };
+        for _ in 0..count {
+            sqlx::query("INSERT INTO verify_proofs
+                (zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count)
+                VALUES ($1,42,$2,$3,$4,$5,14)")
+                .bind(next_id).bind(env.contract_address.to_string()).bind(env.user_address.to_string())
+                .bind(vec![1u8;64]).bind(next_id % 2 == 0).execute(&env.db_pool).await?;
+            next_id += 1;
+        }
+        for n in 0..10u8 {
+            insert_ciphertext_digest(
+                &env.db_pool,
+                host,
+                key,
+                &[40 + cycle * 10 + n; 32],
+                &[2u8; 32],
+                &[3u8; 32],
+                1,
+            )
+            .await?;
+        }
+        let url = proxy.url();
+        let inner = ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .connect_reqwest(gateway_http_client(&url)?, url);
+        let provider =
+            NonceManagedProvider::new(inner, Some(env.wallet.default_signer().address()));
+        let sender = TransactionSender::new(
+            env.db_pool.clone(),
+            *input.address(),
+            *commits.address(),
+            env.signer.clone(),
+            provider,
+            env.cancel_token.clone(),
+            env.conf.clone(),
+            None,
+        )
+        .await?;
+        let calls = proxy.calls("eth_estimateGas");
+        let run = tokio::spawn(async move { sender.run().await });
+        // Require observed retries, rather than accepting an idle sender.
+        tokio::time::timeout(Duration::from_secs(30), async {
+            while proxy.calls("eth_estimateGas") < calls + 40 {
+                assert!(!run.is_finished());
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await?;
+        let early: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM verify_proofs WHERE zk_proof_id <= 10 AND retry_count=14",
+        )
+        .fetch_one(&env.db_pool)
+        .await?;
+        assert_eq!(early, 10, "early work lost eligibility");
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM verify_proofs WHERE zk_proof_id > 10")
+                .fetch_one(&env.db_pool)
+                .await?;
+        later_completed.push(next_id - 11 - remaining);
+        let mutations: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mixed_audit WHERE (old_row->>'zk_proof_id')::bigint <= 10",
+        )
+        .fetch_one(&env.db_pool)
+        .await?;
+        assert_eq!(mutations, 0, "transient failures mutated early proofs");
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let remaining: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM ciphertext_digest WHERE txn_is_sent = false",
+                )
+                .fetch_one(&env.db_pool)
+                .await?;
+                if remaining == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            anyhow::Ok(())
+        })
+        .await??;
+        if cycle == 2 {
+            proxy.clear_all_faults();
+            tokio::time::timeout(Duration::from_secs(60), async {
+                loop {
+                    let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM verify_proofs")
+                        .fetch_one(&env.db_pool)
+                        .await?;
+                    if remaining == 0 {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                anyhow::Ok(())
+            })
+            .await??;
+        }
+        env.cancel_token.cancel();
+        tokio::time::timeout(Duration::from_secs(12), run).await???;
+        env.cancel_token = tokio_util::sync::CancellationToken::new();
+    }
+    let verified = input
+        .VerifyProofResponse_filter()
+        .from_block(0)
+        .query()
+        .await?;
+    let rejected = input
+        .RejectProofResponse_filter()
+        .from_block(0)
+        .query()
+        .await?;
+    let mut ids: Vec<_> = verified
+        .iter()
+        .map(|x| x.0.zkProofId)
+        .chain(rejected.iter().map(|x| x.0.zkProofId))
+        .collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        50,
+        "every logical proof must have contract evidence"
+    );
+    println!("All 50 proofs recovered after two restarts; ciphertexts drained during outage; later proof completions per cycle: {later_completed:?}");
+    assert!(
+        later_completed.iter().all(|n| *n > 0),
+        "selective failures starved later healthy proof batches"
+    );
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_mixed_campaign_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_mixed_campaign_tests.rs
@@ -19,7 +19,7 @@ async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow
         add_ciphertexts_batch_limit: 10,
         verify_proof_resp_max_retries: 15,
         verify_proof_remove_after_max_retries: true,
-        graceful_shutdown_timeout: Duration::from_secs(6),
+        graceful_shutdown_timeout: Duration::from_secs(12),
         ..Default::default()
     };
     let mut env = TestEnvironment::new_with_config(SignerType::PrivateKey, conf, false).await?;
@@ -41,16 +41,6 @@ async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow
     let mut next_id = 1i64;
     let mut later_completed = Vec::new();
     for cycle in 0..3 {
-        // More than two proof batches initially; new work arrives on each restart.
-        let count = if cycle == 0 { 30 } else { 10 };
-        for _ in 0..count {
-            sqlx::query("INSERT INTO verify_proofs
-                (zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count)
-                VALUES ($1,42,$2,$3,$4,$5,14)")
-                .bind(next_id).bind(env.contract_address.to_string()).bind(env.user_address.to_string())
-                .bind(vec![1u8;64]).bind(next_id % 2 == 0).execute(&env.db_pool).await?;
-            next_id += 1;
-        }
         for n in 0..10u8 {
             insert_ciphertext_digest(
                 &env.db_pool,
@@ -83,6 +73,18 @@ async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow
         .await?;
         let calls = proxy.calls("eth_estimateGas");
         let run = tokio::spawn(async move { sender.run().await });
+        // More than two proof batches initially; new work arrives on each restart.
+        let count = if cycle == 0 { 30 } else { 10 };
+        for _ in 0..count {
+            sqlx::query("INSERT INTO verify_proofs
+                (zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count)
+                VALUES ($1,42,$2,$3,$4,$5,14)")
+                .bind(next_id).bind(env.contract_address.to_string()).bind(env.user_address.to_string())
+                .bind(vec![1u8;64]).bind(next_id % 2 == 0).execute(&env.db_pool).await?;
+            next_id += 1;
+            // Keep new work arriving while deferred early proofs become due.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
         // Require observed retries, rather than accepting an idle sender.
         tokio::time::timeout(Duration::from_secs(30), async {
             while proxy.calls("eth_estimateGas") < calls + 40 {
@@ -97,17 +99,33 @@ async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow
         .fetch_one(&env.db_pool)
         .await?;
         assert_eq!(early, 10, "early work lost eligibility");
-        let remaining: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM verify_proofs WHERE zk_proof_id > 10")
-                .fetch_one(&env.db_pool)
-                .await?;
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let remaining: i64 =
+                    sqlx::query_scalar("SELECT COUNT(*) FROM verify_proofs WHERE zk_proof_id > 10")
+                        .fetch_one(&env.db_pool)
+                        .await?;
+                if remaining == 0 {
+                    break;
+                }
+                assert!(!run.is_finished());
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            anyhow::Ok(())
+        })
+        .await??;
+        let remaining = 0;
         later_completed.push(next_id - 11 - remaining);
         let mutations: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM mixed_audit WHERE (old_row->>'zk_proof_id')::bigint <= 10",
+            "SELECT COUNT(*) FROM mixed_audit WHERE (old_row->>'zk_proof_id')::bigint <= 10
+             AND (old_row - 'last_retry_at') IS DISTINCT FROM (new_row - 'last_retry_at')",
         )
         .fetch_one(&env.db_pool)
         .await?;
-        assert_eq!(mutations, 0, "transient failures mutated early proofs");
+        assert_eq!(
+            mutations, 0,
+            "transient failures changed more than retry scheduling"
+        );
         tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 let remaining: i64 = sqlx::query_scalar(
@@ -123,6 +141,15 @@ async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow
             anyhow::Ok(())
         })
         .await??;
+        let retried: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mixed_audit
+             WHERE (old_row->>'zk_proof_id')::bigint <= 10
+               AND old_row->>'last_retry_at' IS NOT NULL
+               AND new_row->>'last_retry_at' IS DISTINCT FROM old_row->>'last_retry_at'",
+        )
+        .fetch_one(&env.db_pool)
+        .await?;
+        assert!(retried > 0, "new arrivals starved deferred retries");
         if cycle == 2 {
             proxy.clear_all_faults();
             tokio::time::timeout(Duration::from_secs(60), async {
@@ -140,7 +167,7 @@ async fn mixed_work_progresses_through_selective_outage_and_restarts() -> anyhow
             .await??;
         }
         env.cancel_token.cancel();
-        tokio::time::timeout(Duration::from_secs(12), run).await???;
+        tokio::time::timeout(Duration::from_secs(15), run).await???;
         env.cancel_token = tokio_util::sync::CancellationToken::new();
     }
     let verified = input

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_otlp_campaign_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_otlp_campaign_tests.rs
@@ -1,0 +1,36 @@
+use alloy::providers::{Provider, ProviderBuilder};
+use fhevm_engine_common::telemetry;
+use transaction_sender::{
+    diagnostics::{gateway_tracing_filter, safe_rpc_error},
+    gateway_http_client,
+};
+
+/// The Python campaign runner captures actual gRPC export payloads and JSON
+/// stdout, requires the positive marker, and rejects every synthetic secret.
+#[tokio::test]
+#[ignore = "requires campaign OTLP receiver"]
+async fn actual_json_and_otlp_exports_exclude_gateway_credentials() -> anyhow::Result<()> {
+    let guard = telemetry::init_json_subscriber_with_filter(
+        tracing::Level::TRACE,
+        "gateway-privacy-campaign",
+        "campaign",
+        gateway_tracing_filter,
+    )
+    .map_err(|_| anyhow::anyhow!("tracing setup failed"))?;
+    let socket = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let port = socket.local_addr()?.port();
+    drop(socket);
+    let url = format!("http://GW_USER_SECRET:GW_PASSWORD_SECRET@127.0.0.1:{port}/GW_PATH_SECRET?key=GW_QUERY_SECRET").parse()?;
+    let provider = ProviderBuilder::new().connect_reqwest(gateway_http_client(&url)?, url);
+    {
+        let span = tracing::info_span!("campaign_export_positive_marker");
+        let _entered = span.enter();
+        tracing::trace!(target: "alloy_rpc_client", "GW_ALLOY_SECRET");
+        tracing::trace!(target: "rustls::client::hs", "GW_TLS_SECRET");
+        let err = provider.get_chain_id().await.unwrap_err();
+        tracing::warn!(error = %safe_rpc_error(&err), "campaign_export_positive_marker");
+    }
+    // Exporter shutdown is blocking, so avoid blocking this Tokio runtime.
+    tokio::task::spawn_blocking(move || drop(guard)).await?;
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_retry_campaign_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_retry_campaign_tests.rs
@@ -156,10 +156,16 @@ async fn transient_failure_preserves_near_exhausted_proof_and_recovers(
     // Four attempts require 1 + 2 + 4 seconds of backoff, even for
     // immediate failures. A success/continue busy loop must fail this check.
     assert!(started.elapsed() >= Duration::from_secs(7));
-    let audit_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM campaign_proof_audit")
-        .fetch_one(&env.db_pool)
-        .await?;
-    assert_eq!(audit_count, 0, "infrastructure failures mutated proof rows");
+    let audit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM campaign_proof_audit
+         WHERE (old_row - 'last_retry_at') IS DISTINCT FROM (new_row - 'last_retry_at')",
+    )
+    .fetch_one(&env.db_pool)
+    .await?;
+    assert_eq!(
+        audit_count, 0,
+        "infrastructure failures changed more than retry scheduling"
+    );
     assert!(
         (proxy.calls(method) - initial_calls) as u64 <= 5 + started.elapsed().as_secs() / 3,
         "attempt rate exceeded bounded operation backoff"

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_retry_campaign_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_retry_campaign_tests.rs
@@ -34,6 +34,15 @@ use transaction_sender::{
 #[case::estimate_504("eth_estimateGas", Fault::HttpError(504), true, true, 0)]
 #[case::nonce_504("eth_getTransactionCount", Fault::HttpError(504), true, true, 0)]
 #[case::send_504("eth_sendRawTransactionSync", Fault::HttpError(504), true, false, 0)]
+#[case::unreadable_estimate_html("eth_estimateGas", Fault::RawResponse { status: 200, body: "<html>maintenance GW_BARE_SECRET</html>".into() }, true, true, 0)]
+#[case::unreadable_estimate_empty("eth_estimateGas", Fault::RawResponse { status: 200, body: "".into() }, true, true, 0)]
+#[case::unreadable_estimate_malformed("eth_estimateGas", Fault::RawResponse { status: 200, body: "{invalid GW_BARE_SECRET".into() }, true, true, 0)]
+#[case::unreadable_nonce_html("eth_getTransactionCount", Fault::RawResponse { status: 200, body: "<html>maintenance GW_BARE_SECRET</html>".into() }, true, true, 0)]
+#[case::unreadable_nonce_empty("eth_getTransactionCount", Fault::RawResponse { status: 200, body: "".into() }, true, true, 0)]
+#[case::unreadable_nonce_malformed("eth_getTransactionCount", Fault::RawResponse { status: 200, body: "{invalid GW_BARE_SECRET".into() }, true, true, 0)]
+#[case::unreadable_send_html("eth_sendRawTransactionSync", Fault::RawResponse { status: 200, body: "<html>maintenance GW_BARE_SECRET</html>".into() }, true, true, 0)]
+#[case::unreadable_send_empty("eth_sendRawTransactionSync", Fault::RawResponse { status: 200, body: "".into() }, true, true, 0)]
+#[case::unreadable_send_malformed("eth_sendRawTransactionSync", Fault::RawResponse { status: 200, body: "{invalid GW_BARE_SECRET".into() }, true, true, 0)]
 #[case::long_outage_true("eth_sendRawTransactionSync", Fault::HttpError(503), true, true, 300)]
 #[case::long_outage_false("eth_sendRawTransactionSync", Fault::HttpError(503), false, true, 300)]
 #[case::estimate_never_answers(
@@ -153,8 +162,8 @@ async fn transient_failure_preserves_near_exhausted_proof_and_recovers(
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
-    // Four attempts require 1 + 2 + 4 seconds of backoff, even for
-    // immediate failures. A success/continue busy loop must fail this check.
+    // Retain the original minimum backoff bound; per-proof cooldown may
+    // increase it. An immediate retry loop must fail this check.
     assert!(started.elapsed() >= Duration::from_secs(7));
     let audit_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM campaign_proof_audit

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gateway_retry_campaign_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gateway_retry_campaign_tests.rs
@@ -1,0 +1,214 @@
+//! Focused preservation/recovery regressions. The broader campaign is described
+//! in docs/transaction-sender-http-proof-retry-test-protocol.md.
+mod common;
+mod support;
+
+use alloy::primitives::U256;
+use alloy::providers::ProviderBuilder;
+use common::{CiphertextCommits, InputVerification, SignerType, TestEnvironment};
+use rstest::rstest;
+use serial_test::serial;
+use std::time::Duration;
+use support::{Fault, FaultProxy};
+use transaction_sender::{
+    gateway_http_client, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
+    TransactionSender,
+};
+
+#[rstest]
+#[case::estimate_408("eth_estimateGas", Fault::HttpError(408), true, true, 0)]
+#[case::nonce_408("eth_getTransactionCount", Fault::HttpError(408), true, true, 0)]
+#[case::send_408("eth_sendRawTransactionSync", Fault::HttpError(408), true, false, 0)]
+#[case::estimate_429("eth_estimateGas", Fault::HttpError(429), false, true, 0)]
+#[case::nonce_429("eth_getTransactionCount", Fault::HttpError(429), false, true, 0)]
+#[case::send_429("eth_sendRawTransactionSync", Fault::HttpError(429), false, false, 0)]
+#[case::estimate_500("eth_estimateGas", Fault::HttpError(500), true, true, 0)]
+#[case::nonce_500("eth_getTransactionCount", Fault::HttpError(500), true, true, 0)]
+#[case::send_500("eth_sendRawTransactionSync", Fault::HttpError(500), true, false, 0)]
+#[case::estimate_502("eth_estimateGas", Fault::HttpError(502), true, true, 0)]
+#[case::nonce_502("eth_getTransactionCount", Fault::HttpError(502), true, true, 0)]
+#[case::send_502("eth_sendRawTransactionSync", Fault::HttpError(502), true, false, 0)]
+#[case::estimate_503("eth_estimateGas", Fault::HttpError(503), false, true, 0)]
+#[case::nonce_503("eth_getTransactionCount", Fault::HttpError(503), false, true, 0)]
+#[case::send_503("eth_sendRawTransactionSync", Fault::HttpError(503), false, false, 0)]
+#[case::estimate_504("eth_estimateGas", Fault::HttpError(504), true, true, 0)]
+#[case::nonce_504("eth_getTransactionCount", Fault::HttpError(504), true, true, 0)]
+#[case::send_504("eth_sendRawTransactionSync", Fault::HttpError(504), true, false, 0)]
+#[case::long_outage_true("eth_sendRawTransactionSync", Fault::HttpError(503), true, true, 300)]
+#[case::long_outage_false("eth_sendRawTransactionSync", Fault::HttpError(503), false, true, 300)]
+#[case::estimate_never_answers(
+    "eth_estimateGas",
+    Fault::DiscardAfter(Duration::from_secs(90)),
+    true,
+    true,
+    0
+)]
+#[case::send_local_timeout(
+    "eth_sendRawTransactionSync",
+    Fault::DiscardAfter(Duration::from_secs(10)),
+    false,
+    false,
+    0
+)]
+#[case::conduit_deadline("eth_sendRawTransactionSync", Fault::RpcError { code: -32000, message: "context deadline exceeded".into() }, true, true, 0)]
+#[case::rpc_unavailable("eth_estimateGas", Fault::RpcError { code: -32603, message: "temporarily unavailable".into() }, false, false, 0)]
+#[case::connection_drop_estimate("eth_estimateGas", Fault::DisconnectBeforeForward, true, true, 0)]
+#[case::connection_drop_send(
+    "eth_sendRawTransactionSync",
+    Fault::DisconnectBeforeForward,
+    false,
+    false,
+    0
+)]
+#[tokio::test]
+#[ignore = "extended validation campaign"]
+#[serial(db)]
+async fn transient_failure_preserves_near_exhausted_proof_and_recovers(
+    #[case] method: &str,
+    #[case] fault: Fault,
+    #[case] remove: bool,
+    #[case] verified: bool,
+    #[case] outage_seconds: u64,
+) -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        verify_proof_resp_max_retries: 15,
+        verify_proof_remove_after_max_retries: remove,
+        error_sleep_initial_secs: 1,
+        error_sleep_max_secs: 4,
+        send_txn_sync_timeout_secs: 1,
+        graceful_shutdown_timeout: Duration::from_secs(5),
+        ..Default::default()
+    };
+    let env = TestEnvironment::new_with_config(SignerType::PrivateKey, conf, false).await?;
+    let deploy = env.http_provider()?;
+    let input = InputVerification::deploy(&deploy, false, false, false, false).await?;
+    let ciphertext = CiphertextCommits::deploy(&deploy, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+    let url = proxy.url();
+    let inner = ProviderBuilder::default()
+        .filler(FillersWithoutNonceManagement::default())
+        .wallet(env.wallet.clone())
+        .connect_reqwest(gateway_http_client(&url)?, url);
+    let provider = NonceManagedProvider::new(inner, Some(env.wallet.default_signer().address()));
+    let sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input.address(),
+        *ciphertext.address(),
+        env.signer.clone(),
+        provider,
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id = i64::from(rand::random::<u32>());
+    sqlx::query(
+        "INSERT INTO verify_proofs
+         (zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count)
+         VALUES ($1, 42, $2, $3, $4, $5, 14)",
+    )
+    .bind(proof_id)
+    .bind(env.contract_address.to_string())
+    .bind(env.user_address.to_string())
+    .bind(vec![1u8; 64])
+    .bind(verified)
+    .execute(&env.db_pool)
+    .await?;
+
+    sqlx::raw_sql(
+        "CREATE TABLE campaign_proof_audit (old_row jsonb, new_row jsonb);
+        CREATE FUNCTION audit_campaign_proof() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN INSERT INTO campaign_proof_audit VALUES (to_jsonb(OLD), to_jsonb(NEW));
+        RETURN NULL; END $$;
+        CREATE TRIGGER campaign_proof_audit AFTER UPDATE OR DELETE ON verify_proofs
+        FOR EACH ROW EXECUTE FUNCTION audit_campaign_proof();",
+    )
+    .execute(&env.db_pool)
+    .await?;
+    proxy.set_fault(method, fault, None);
+    let initial_calls = proxy.calls(method);
+    let started = tokio::time::Instant::now();
+    let run = tokio::spawn(async move { sender.run().await });
+    let deadline = started + Duration::from_secs(outage_seconds + 180);
+    loop {
+        let retries: Option<i32> =
+            sqlx::query_scalar("SELECT retry_count FROM verify_proofs WHERE zk_proof_id = $1")
+                .bind(proof_id)
+                .fetch_optional(&env.db_pool)
+                .await?;
+        assert_eq!(
+            retries,
+            Some(14),
+            "transient error must not exhaust or delete proof"
+        );
+        assert!(!run.is_finished());
+        if proxy.calls(method) - initial_calls >= 4 && started.elapsed().as_secs() >= outage_seconds
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "fault was not exercised repeatedly"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    // Four attempts require 1 + 2 + 4 seconds of backoff, even for
+    // immediate failures. A success/continue busy loop must fail this check.
+    assert!(started.elapsed() >= Duration::from_secs(7));
+    let audit_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM campaign_proof_audit")
+        .fetch_one(&env.db_pool)
+        .await?;
+    assert_eq!(audit_count, 0, "infrastructure failures mutated proof rows");
+    assert!(
+        (proxy.calls(method) - initial_calls) as u64 <= 5 + started.elapsed().as_secs() / 3,
+        "attempt rate exceeded bounded operation backoff"
+    );
+
+    // An already-started estimate may use the remaining 30-second HTTP
+    // deadline after restoration; allow that plus backoff and drain time.
+    let recovery_secs = if method == "eth_estimateGas" { 50 } else { 20 };
+    proxy.clear_all_faults();
+    tokio::time::timeout(Duration::from_secs(recovery_secs), async {
+        loop {
+            let present: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM verify_proofs WHERE zk_proof_id = $1)",
+            )
+            .bind(proof_id)
+            .fetch_one(&env.db_pool)
+            .await?;
+            if !present {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        anyhow::Ok(())
+    })
+    .await??;
+
+    // Deletion alone is not success: require the matching on-chain event.
+    if verified {
+        let events = input
+            .VerifyProofResponse_filter()
+            .from_block(0)
+            .query()
+            .await?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0.zkProofId, U256::from(proof_id as u64));
+        assert_eq!(
+            events[0].0.ctHandles,
+            vec![alloy::primitives::FixedBytes([1u8; 32]); 2]
+        );
+    } else {
+        let events = input
+            .RejectProofResponse_filter()
+            .from_block(0)
+            .query()
+            .await?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0.zkProofId, U256::from(proof_id as u64));
+    }
+    env.cancel_token.cancel();
+    tokio::time::timeout(Duration::from_secs(10), run).await???;
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gw_patch_campaign.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gw_patch_campaign.rs
@@ -53,7 +53,7 @@ enum Transport {
 }
 
 impl Transport {
-    /// Strict: an unrecognised value panics rather than silently defaulting.
+    /// Strict: an unrecognized value panics rather than silently defaulting.
     /// A silent default here mislabelled a whole arm of an earlier comparison.
     fn from_env() -> Self {
         let raw = std::env::var("GW_TRANSPORT").unwrap_or_else(|_| "https".into());
@@ -79,7 +79,6 @@ struct Secrets {
     /// Every (address, key) pair in the file, in order. The first is the
     /// primary account used by single-account runs.
     accounts: Vec<(Address, String)>,
-    recipient: Option<Address>,
 }
 
 impl Secrets {
@@ -92,12 +91,6 @@ impl Secrets {
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("no http(s) Gateway URL available"))?,
         })
-    }
-    fn address(&self) -> Address {
-        self.accounts[0].0
-    }
-    fn pkey(&self) -> &str {
-        &self.accounts[0].1
     }
 }
 
@@ -114,7 +107,6 @@ fn load_secrets() -> anyhow::Result<Secrets> {
 
     let mut wss = None;
     let mut https = None;
-    let mut recipient = None;
     // Address/Pkey lines come in pairs, possibly repeated for extra accounts.
     let mut pending_address: Option<Address> = None;
     let mut accounts: Vec<(Address, String)> = Vec::new();
@@ -159,7 +151,6 @@ fn load_secrets() -> anyhow::Result<Secrets> {
                     .ok_or_else(|| anyhow::anyhow!("a Pkey line has no preceding Address line"))?;
                 accounts.push((a, value.to_string()));
             }
-            "recipient" | "gw_recipient" => recipient = Some(Address::from_str(value)?),
             _ => {}
         }
     }
@@ -176,7 +167,6 @@ fn load_secrets() -> anyhow::Result<Secrets> {
         // driver probes it at startup and records that it was derived, not given.
         https: https.or_else(|| wss.map(|u| u.replacen("wss://", "https://", 1))),
         accounts,
-        recipient,
     })
 }
 
@@ -193,7 +183,7 @@ fn old_redacted_endpoint(url: &str) -> String {
             let host = rest.split(['/', '?']).next().unwrap_or("");
             format!("{scheme}://{host}/<redacted>")
         }
-        None => "<unparseable>".to_string(),
+        None => "<unparsable>".to_string(),
     }
 }
 
@@ -299,7 +289,7 @@ fn pct(sorted: &[f64], p: f64) -> f64 {
     sorted[idx]
 }
 
-fn summarise(label: &str, mut v: Vec<f64>) {
+fn summarize(label: &str, mut v: Vec<f64>) {
     if v.is_empty() {
         println!("  {label:<26}: no samples");
         return;
@@ -765,13 +755,13 @@ async fn run_campaign() -> anyhow::Result<()> {
 (sampled {} in-window)",
             tx_ms.len()
         );
-        summarise("  per-tx total", tx_ms.clone());
-        summarise(
+        summarize("  per-tx total", tx_ms.clone());
+        summarize(
             "  gas estimate",
             samples.estimate_ms.lock().unwrap().clone(),
         );
         if !pool_mode {
-            summarise(
+            summarize(
                 "  batch wall time",
                 samples.batch_ms.lock().unwrap().clone(),
             );

--- a/coprocessor/fhevm-engine/transaction-sender/tests/gw_patch_campaign.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/gw_patch_campaign.rs
@@ -1,0 +1,829 @@
+//! Baseline (pre-hotfix v0.13.4) submission driver against the real Gateway.
+//!
+//! This measures the shape the *unchanged* v0.13.4 sender actually runs, with
+//! only the transport moved from WebSocket to HTTP:
+//!
+//! * a batch of up to `batch_limit` rows is selected,
+//! * one task is spawned per row,
+//! * each task estimates gas, takes the nonce mutex briefly to allocate a
+//!   nonce, releases it, then calls `eth_sendRawTransactionSync`,
+//! * the whole batch is joined before the next batch is selected.
+//!
+//! That join barrier is part of the design and is reproduced here: a single
+//! slow submission holds up the next batch. Two operations (verify-proof and
+//! add-ciphertexts) run as independent loops, so production concurrency is
+//! `batch_limit x operations`, not an unbounded pool.
+//!
+//! Ignored by default; driven from an env file so no secret reaches `argv`,
+//! shell history or this test's output. Only the derived signer address, error
+//! classes and sanitized endpoint (`scheme://host/<redacted>`) are ever logged.
+//!
+//! ```sh
+//! GW_ENV_FILE=~/.config/fhevm-gw-test.env \
+//!   cargo test --release --locked -p transaction-sender \
+//!   --test gw_baseline_capacity -- --ignored --nocapture
+//! ```
+
+#![cfg(test)]
+
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use alloy::network::{EthereumWallet, TransactionBuilder};
+use alloy::primitives::{Address, U256};
+use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::Signer;
+use transaction_sender::{
+    gateway_http_client, FillersWithoutNonceManagement, NonceManagedProvider,
+};
+
+/// Which transport the measured provider uses.
+/// `https` builds exactly what the release binary builds: `gateway_http_client`
+/// (4 s connect, 30 s request, no redirects, no transport retry) driven through
+/// `connect_reqwest`. `wss` reconstructs the pre-migration provider for the
+/// side-by-side comparison, since the saved WSS build is not available here.
+#[derive(Clone, Copy, PartialEq)]
+enum Transport {
+    Https,
+    Wss,
+}
+
+impl Transport {
+    /// Strict: an unrecognised value panics rather than silently defaulting.
+    /// A silent default here mislabelled a whole arm of an earlier comparison.
+    fn from_env() -> Self {
+        let raw = std::env::var("GW_TRANSPORT").unwrap_or_else(|_| "https".into());
+        match raw.to_ascii_lowercase().as_str() {
+            "wss" | "ws" => Transport::Wss,
+            "https" | "http" => Transport::Https,
+            other => panic!("GW_TRANSPORT={other:?} is not one of https|wss"),
+        }
+    }
+    fn label(&self) -> &'static str {
+        match self {
+            Transport::Https => "https",
+            Transport::Wss => "wss",
+        }
+    }
+}
+
+// ---------------------------------------------------------------- config ---
+
+struct Secrets {
+    wss: String,
+    https: Option<String>,
+    /// Every (address, key) pair in the file, in order. The first is the
+    /// primary account used by single-account runs.
+    accounts: Vec<(Address, String)>,
+    recipient: Option<Address>,
+}
+
+impl Secrets {
+    /// URL for the transport under test.
+    fn url_for(&self, t: Transport) -> anyhow::Result<String> {
+        Ok(match t {
+            Transport::Wss => self.wss.clone(),
+            Transport::Https => self
+                .https
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("no http(s) Gateway URL available"))?,
+        })
+    }
+    fn address(&self) -> Address {
+        self.accounts[0].0
+    }
+    fn pkey(&self) -> &str {
+        &self.accounts[0].1
+    }
+}
+
+/// Parses the free-form `label: value` env file. Values are never printed.
+fn load_secrets() -> anyhow::Result<Secrets> {
+    let path = std::env::var("GW_ENV_FILE").unwrap_or_else(|_| {
+        format!(
+            "{}/.config/fhevm-gw-test.env",
+            std::env::var("HOME").unwrap_or_default()
+        )
+    });
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("cannot read GW_ENV_FILE {path}: {e}"))?;
+
+    let mut wss = None;
+    let mut https = None;
+    let mut recipient = None;
+    // Address/Pkey lines come in pairs, possibly repeated for extra accounts.
+    let mut pending_address: Option<Address> = None;
+    let mut accounts: Vec<(Address, String)> = Vec::new();
+
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // A bare URL line, with no "Label:" prefix.
+        if line.starts_with("wss://") || line.starts_with("ws://") {
+            wss = Some(line.to_string());
+            continue;
+        }
+        if line.starts_with("https://") || line.starts_with("http://") {
+            https = Some(line.to_string());
+            continue;
+        }
+        let Some(idx) = line.find([':', '=']) else {
+            continue;
+        };
+        let (label, value) = line.split_at(idx);
+        let value = value[1..].trim();
+        if value.is_empty() {
+            continue;
+        }
+        match label.trim().to_ascii_lowercase().replace(' ', "_").as_str() {
+            "https" | "gw_https" => https = Some(value.to_string()),
+            "wss" | "gw_wss" | "url" => {
+                // Tolerate "WSS: wss://..." and a value that lost its scheme
+                // because the split landed inside "wss://".
+                wss = Some(if value.starts_with("//") {
+                    format!("wss:{value}")
+                } else {
+                    value.to_string()
+                });
+            }
+            "address" | "gw_address" => pending_address = Some(Address::from_str(value)?),
+            "pkey" | "gw_pkey" | "private_key" => {
+                let a = pending_address
+                    .take()
+                    .ok_or_else(|| anyhow::anyhow!("a Pkey line has no preceding Address line"))?;
+                accounts.push((a, value.to_string()));
+            }
+            "recipient" | "gw_recipient" => recipient = Some(Address::from_str(value)?),
+            _ => {}
+        }
+    }
+    anyhow::ensure!(
+        !accounts.is_empty(),
+        "env file defines no Address/Pkey pair"
+    );
+    Ok(Secrets {
+        wss: wss
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("env file has no endpoint URL"))?,
+        // If infra supplied no explicit HTTPS URL, fall back to substituting the
+        // scheme. The strategy document warns not to assume this works, so the
+        // driver probes it at startup and records that it was derived, not given.
+        https: https.or_else(|| wss.map(|u| u.replacen("wss://", "https://", 1))),
+        accounts,
+        recipient,
+    })
+}
+
+/// Endpoint identity safe to log: scheme and host only, never the path, which
+/// is where Conduit carries its auth token.
+fn redacted_endpoint(_url: &str) -> String {
+    "<Gateway endpoint redacted>".to_string()
+}
+
+#[allow(dead_code)]
+fn old_redacted_endpoint(url: &str) -> String {
+    match url.split_once("://") {
+        Some((scheme, rest)) => {
+            let host = rest.split(['/', '?']).next().unwrap_or("");
+            format!("{scheme}://{host}/<redacted>")
+        }
+        None => "<unparseable>".to_string(),
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Hard stops. Any breach halts new work; it never silently continues.
+struct Ceilings {
+    max_attempts: u64,
+    max_spend_wei: u128,
+    max_unresolved: u64,
+    max_secs: u64,
+    tripped: AtomicBool,
+    reason: std::sync::Mutex<Option<String>>,
+}
+
+impl Ceilings {
+    fn from_env() -> Self {
+        Self {
+            max_attempts: env_u64("GW_MAX_ATTEMPTS", 200),
+            // 0.02 ETH default for the pilot: a tenth of the funded budget.
+            max_spend_wei: std::env::var("GW_MAX_SPEND_WEI")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(20_000_000_000_000_000u128),
+            max_unresolved: env_u64("GW_MAX_UNRESOLVED", 32),
+            max_secs: env_u64("GW_MAX_SECS", 600),
+            tripped: AtomicBool::new(false),
+            reason: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn trip(&self, why: impl Into<String>) {
+        if !self.tripped.swap(true, Ordering::SeqCst) {
+            *self.reason.lock().unwrap() = Some(why.into());
+        }
+    }
+
+    fn is_tripped(&self) -> bool {
+        self.tripped.load(Ordering::SeqCst)
+    }
+}
+
+/// Includes confirmed fees plus maximum reservations for outstanding or
+/// ambiguous sends. Only a mined receipt can refund a submission reservation.
+struct SpendBudget {
+    charged: std::sync::Mutex<u128>,
+    limit: u128,
+    per_send: u128,
+}
+impl SpendBudget {
+    fn reserve(&self, count: u64) -> bool {
+        let mut charged = self.charged.lock().unwrap();
+        let Some(next) = self
+            .per_send
+            .checked_mul(count as u128)
+            .and_then(|amount| charged.checked_add(amount))
+        else {
+            return false;
+        };
+        if next > self.limit {
+            return false;
+        }
+        *charged = next;
+        true
+    }
+    fn settle(&self, actual: u128) {
+        assert!(
+            actual <= self.per_send,
+            "receipt exceeded maximum gas reservation"
+        );
+        *self.charged.lock().unwrap() -= self.per_send - actual;
+    }
+}
+
+#[test]
+fn reservation_refunds_only_confirmed_costs() {
+    let b = SpendBudget {
+        charged: std::sync::Mutex::new(0),
+        limit: 100,
+        per_send: 40,
+    };
+    assert!(b.reserve(2));
+    assert!(!b.reserve(1));
+    b.settle(10);
+    assert!(b.reserve(1));
+    // One ambiguous send stays reserved at 40; only confirmed work is refunded.
+    assert_eq!(*b.charged.lock().unwrap(), 90);
+    b.settle(20);
+    assert_eq!(*b.charged.lock().unwrap(), 70);
+    assert!(!b.reserve(1));
+}
+
+fn pct(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted[idx]
+}
+
+fn summarise(label: &str, mut v: Vec<f64>) {
+    if v.is_empty() {
+        println!("  {label:<26}: no samples");
+        return;
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mean = v.iter().sum::<f64>() / v.len() as f64;
+    println!(
+        "  {label:<26}: n={:<5} mean={:>8.1} p50={:>8.1} p90={:>8.1} p99={:>8.1} max={:>8.1} ms",
+        v.len(),
+        mean,
+        pct(&v, 0.50),
+        pct(&v, 0.90),
+        pct(&v, 0.99),
+        v[v.len() - 1]
+    );
+}
+
+/// Builds the provider under test.
+///
+/// `https` builds exactly what this branch's binary builds: `gateway_http_client`
+/// (4 s connect, 30 s request ceiling, no redirects, no transport retry) driven
+/// through `connect_reqwest`. `wss` reconstructs the pre-migration provider so
+/// the transport change can be attributed.
+async fn build_provider(
+    t: Transport,
+    url: &str,
+    wallet: EthereumWallet,
+    signer_addr: Address,
+) -> anyhow::Result<NonceManagedProvider<alloy::providers::DynProvider>> {
+    let base = ProviderBuilder::default()
+        .filler(FillersWithoutNonceManagement::default())
+        .wallet(wallet);
+    let inner = match t {
+        Transport::Https => {
+            let parsed: alloy::transports::http::reqwest::Url = url.parse()?;
+            base.connect_reqwest(gateway_http_client(&parsed)?, parsed)
+                .erased()
+        }
+        Transport::Wss => base
+            .connect_ws(WsConnect::new(url.to_string()))
+            .await?
+            .erased(),
+    };
+    Ok(NonceManagedProvider::new(inner, Some(signer_addr)))
+}
+
+/// Outcomes kept apart rather than lumped into an error count. A lost response
+/// is an ambiguous acceptance, not a rejection, and the two must not be summed.
+#[derive(Default)]
+struct Outcomes {
+    ok: AtomicU64,
+    reverted: AtomicU64,
+    send_timeout: AtomicU64,
+    nonce_low: AtomicU64,
+    nonce_high: AtomicU64,
+    already_known: AtomicU64,
+    null_response: AtomicU64,
+    underpriced: AtomicU64,
+    other: AtomicU64,
+    estimate_failed: AtomicU64,
+    samples: std::sync::Mutex<Vec<String>>,
+}
+
+impl Outcomes {
+    fn classify(&self, e: &str) {
+        let l = e.to_ascii_lowercase();
+        if l.contains("eth_sendrawtransactionsync timeout") || l.contains("sync timeout") {
+            self.send_timeout.fetch_add(1, Ordering::Relaxed);
+        } else if l.contains("nonce too low") {
+            self.nonce_low.fetch_add(1, Ordering::Relaxed);
+        } else if l.contains("nonce too high") || l.contains("nonce gap") {
+            self.nonce_high.fetch_add(1, Ordering::Relaxed);
+        } else if l.contains("already known") || l.contains("already imported") {
+            self.already_known.fetch_add(1, Ordering::Relaxed);
+        } else if l.contains("null response") {
+            self.null_response.fetch_add(1, Ordering::Relaxed);
+        } else if l.contains("underpriced") {
+            self.underpriced.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.other.fetch_add(1, Ordering::Relaxed);
+        }
+        let mut v = self.samples.lock().unwrap();
+        if v.len() < 10 && !v.iter().any(|s| s == e) {
+            v.push(e.to_string());
+        }
+    }
+
+    fn total_errors(&self) -> u64 {
+        self.send_timeout.load(Ordering::Relaxed)
+            + self.nonce_low.load(Ordering::Relaxed)
+            + self.nonce_high.load(Ordering::Relaxed)
+            + self.already_known.load(Ordering::Relaxed)
+            + self.null_response.load(Ordering::Relaxed)
+            + self.underpriced.load(Ordering::Relaxed)
+            + self.other.load(Ordering::Relaxed)
+            + self.estimate_failed.load(Ordering::Relaxed)
+    }
+
+    fn report(&self) {
+        println!(
+            "  outcomes: ok={} reverted={} | send_timeout={} nonce_low={} nonce_high={} \
+already_known={} null_response={} underpriced={} estimate_failed={} other={}",
+            self.ok.load(Ordering::Relaxed),
+            self.reverted.load(Ordering::Relaxed),
+            self.send_timeout.load(Ordering::Relaxed),
+            self.nonce_low.load(Ordering::Relaxed),
+            self.nonce_high.load(Ordering::Relaxed),
+            self.already_known.load(Ordering::Relaxed),
+            self.null_response.load(Ordering::Relaxed),
+            self.underpriced.load(Ordering::Relaxed),
+            self.estimate_failed.load(Ordering::Relaxed),
+            self.other.load(Ordering::Relaxed),
+        );
+        for m in self.samples.lock().unwrap().iter() {
+            let _ = m; // Raw upstream error samples deliberately withheld.
+        }
+    }
+}
+
+struct Samples {
+    tx_ms: std::sync::Mutex<Vec<f64>>,
+    estimate_ms: std::sync::Mutex<Vec<f64>>,
+    batch_ms: std::sync::Mutex<Vec<f64>>,
+}
+
+impl Samples {
+    fn new() -> Self {
+        Self {
+            tx_ms: std::sync::Mutex::new(Vec::new()),
+            estimate_ms: std::sync::Mutex::new(Vec::new()),
+            batch_ms: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+    fn clear(&self) {
+        self.tx_ms.lock().unwrap().clear();
+        self.estimate_ms.lock().unwrap().clear();
+        self.batch_ms.lock().unwrap().clear();
+    }
+}
+
+/// One transaction the way the baseline operation code sends one: estimate the
+/// gas limit, overprovision it, then a single bounded `send_transaction_sync`.
+#[allow(clippy::too_many_arguments)]
+async fn send_one(
+    provider: &NonceManagedProvider<alloy::providers::DynProvider>,
+    tx: TransactionRequest,
+    estimate: bool,
+    overprovision_pct: u32,
+    send_timeout: Duration,
+    outcomes: &Outcomes,
+    samples: &Samples,
+    measuring: &std::sync::atomic::AtomicBool,
+    budget: &SpendBudget,
+) {
+    let t0 = Instant::now();
+    let prepared = if estimate {
+        match provider
+            .overprovision_gas_limit(tx.clone(), overprovision_pct)
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                budget.settle(0); // No submission was attempted.
+                outcomes.estimate_failed.fetch_add(1, Ordering::Relaxed);
+                outcomes.classify(&e.to_string());
+                return;
+            }
+        }
+    } else {
+        tx
+    };
+    // The budget assumes a bounded gas limit. Do not submit if estimation
+    // violates that assumption (e.g. a recipient unexpectedly acquired code).
+    if prepared.gas.unwrap_or(u64::MAX) > 25_200 {
+        budget.settle(0);
+        outcomes.estimate_failed.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    let t_est = Instant::now();
+    let res = provider.send_transaction_sync(prepared, send_timeout).await;
+    let done = Instant::now();
+    if measuring.load(Ordering::Relaxed) {
+        samples
+            .estimate_ms
+            .lock()
+            .unwrap()
+            .push((t_est - t0).as_secs_f64() * 1000.0);
+        samples
+            .tx_ms
+            .lock()
+            .unwrap()
+            .push((done - t0).as_secs_f64() * 1000.0);
+    }
+    match res {
+        Ok(receipt) => {
+            budget.settle(receipt.effective_gas_price * u128::from(receipt.gas_used));
+            if receipt.status() {
+                outcomes.ok.fetch_add(1, Ordering::Relaxed);
+            } else {
+                outcomes.reverted.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        Err(e) => outcomes.classify(&e.to_string()),
+    }
+}
+
+/// Full evaluation of the baseline submission shape against the Gateway.
+///
+/// `GW_MODE=batch` (default) reproduces the operation loop with its join
+/// barrier; `GW_MODE=pool` runs a continuous worker pool of the same width, so
+/// the barrier's cost can be separated from the concurrency's benefit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore]
+async fn gw_baseline_sweep() -> Result<(), String> {
+    run_campaign()
+        .await
+        .map_err(|_| "Gateway campaign failed; raw error withheld".to_string())
+}
+
+async fn run_campaign() -> anyhow::Result<()> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let s = load_secrets()?;
+    let transport = Transport::from_env();
+    let url = s.url_for(transport)?;
+    let ceilings = Arc::new(Ceilings::from_env());
+
+    let batch_sweep: Vec<usize> = std::env::var("GW_SWEEP")
+        .unwrap_or_else(|_| "10".into())
+        .split(',')
+        .filter_map(|v| v.trim().parse().ok())
+        .collect();
+    anyhow::ensure!(
+        batch_sweep.len() == 1,
+        "one batch configuration per process required"
+    );
+    let ops = env_u64("GW_OPS", 2) as usize;
+    let warmup = env_u64("GW_WARMUP", 20);
+    let measure = env_u64("GW_MEASURE", 60);
+    let n_accounts = (env_u64("GW_ACCOUNTS", 1) as usize).min(s.accounts.len());
+    let acct_offset = (env_u64("GW_ACCOUNT_OFFSET", 0) as usize).min(s.accounts.len() - 1);
+    let send_timeout = Duration::from_millis(env_u64("GW_SEND_TIMEOUT_MS", 4000));
+    let estimate = env_u64("GW_ESTIMATE", 1) == 1;
+    let overprovision_pct = env_u64("GW_OVERPROVISION_PCT", 120) as u32;
+    anyhow::ensure!(
+        estimate && overprovision_pct == 120,
+        "campaign requires estimation and 120 percent gas limit"
+    );
+    let pool_mode = std::env::var("GW_MODE").unwrap_or_else(|_| "batch".into()) == "pool";
+
+    println!("======= v0.13.4 baseline submission, HTTP transport =======");
+    println!("transport   : {}", transport.label());
+    println!("endpoint    : {}", redacted_endpoint(&url));
+    println!(
+        "mode        : {}",
+        if pool_mode {
+            "pool (no join barrier)"
+        } else {
+            "batch (join barrier, as the operation loop runs)"
+        }
+    );
+    println!("batch sweep : {batch_sweep:?} per operation x {ops} operation(s)");
+    println!("send timeout: {send_timeout:?}   gas estimation: {estimate}");
+    println!(
+        "accounts    : {n_accounts} (offset {acct_offset}), warm {warmup}s, measure {measure}s"
+    );
+
+    let probe: alloy::providers::DynProvider = match transport {
+        Transport::Https => {
+            let parsed: alloy::transports::http::reqwest::Url = url.parse()?;
+            ProviderBuilder::new()
+                .connect_reqwest(gateway_http_client(&parsed)?, parsed)
+                .erased()
+        }
+        Transport::Wss => ProviderBuilder::new()
+            .connect_ws(WsConnect::new(url.clone()))
+            .await?
+            .erased(),
+    };
+    let t_cold = Instant::now();
+    let chain_id = probe.get_chain_id().await?;
+    println!(
+        "cold setup  : {:.1} ms (first request incl. connect/TLS), chain {chain_id}",
+        t_cold.elapsed().as_secs_f64() * 1000.0
+    );
+
+    let mut wallets = Vec::new();
+    for (addr, pk) in s.accounts.iter().skip(acct_offset).take(n_accounts) {
+        let mut sg = PrivateKeySigner::from_str(pk.trim())?;
+        sg.set_chain_id(Some(chain_id));
+        anyhow::ensure!(sg.address() == *addr, "key/address mismatch for {addr}");
+        let latest = probe.get_transaction_count(*addr).await?;
+        let pending = probe.get_transaction_count(*addr).pending().await?;
+        anyhow::ensure!(
+            latest == pending,
+            "account {addr} has {} unmined transaction(s); reconcile first",
+            pending - latest
+        );
+        println!("  account {addr}  nonce {latest}");
+        wallets.push((*addr, EthereumWallet::from(sg)));
+    }
+    let recipient = Address::from_str(&std::env::var("GW_RECIPIENT")?)?;
+    let mut start_nonces = Vec::new();
+    let mut start_balances = Vec::new();
+    for (addr, _) in &wallets {
+        start_nonces.push(probe.get_transaction_count(*addr).await?);
+        start_balances.push(probe.get_balance(*addr).await?);
+    }
+
+    let attempts = Arc::new(AtomicU64::new(0));
+    let mut rows = Vec::new();
+    for &batch in &batch_sweep {
+        if ceilings.is_tripped() {
+            break;
+        }
+        let outcomes = Arc::new(Outcomes::default());
+        let samples = Arc::new(Samples::new());
+        let measuring = Arc::new(AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        let done_count = Arc::new(AtomicU64::new(0));
+
+        let mut providers = Vec::new();
+        for (addr, w) in &wallets {
+            providers.push(build_provider(transport, &url, w.clone(), *addr).await?);
+        }
+        let fees = probe.estimate_eip1559_fees().await?;
+        // Every transaction is a zero-value transfer to an EOA; reserve at the
+        // maximum fee and overprovisioned gas limit before launching a batch.
+        anyhow::ensure!(
+            probe.get_code_at(recipient).await?.is_empty(),
+            "recipient must be EOA"
+        );
+        let worst_cost = fees.max_fee_per_gas.saturating_mul(25_200);
+        anyhow::ensure!(worst_cost > 0, "invalid fee estimate");
+        let budget = Arc::new(SpendBudget {
+            charged: std::sync::Mutex::new(0),
+            limit: ceilings.max_spend_wei,
+            per_send: worst_cost,
+        });
+        let allowed = ceilings.max_attempts;
+        anyhow::ensure!(
+            batch * ops * n_accounts <= ceilings.max_unresolved as usize,
+            "concurrency ceiling"
+        );
+
+        let mut loops = tokio::task::JoinSet::new();
+        for provider in providers.iter() {
+            for _op in 0..ops {
+                let provider = provider.clone();
+                let outcomes = outcomes.clone();
+                let samples = samples.clone();
+                let measuring = measuring.clone();
+                let stop = stop.clone();
+                let ceilings = ceilings.clone();
+                let done_count = done_count.clone();
+                let attempts = attempts.clone();
+                let budget = budget.clone();
+                let tx = TransactionRequest::default()
+                    .with_to(recipient)
+                    .with_value(U256::ZERO)
+                    .with_chain_id(chain_id)
+                    .with_max_fee_per_gas(fees.max_fee_per_gas)
+                    .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
+                loops.spawn(async move {
+                    while !stop.load(Ordering::Relaxed) && !ceilings.is_tripped() {
+                        let width = if pool_mode { 1 } else { batch as u64 };
+                        if attempts
+                            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                                n.checked_add(width).filter(|v| *v <= allowed)
+                            })
+                            .is_err()
+                        {
+                            ceilings.trip("attempt or reserved-spend ceiling");
+                            break;
+                        }
+                        if !budget.reserve(width) {
+                            ceilings.trip(
+                                "spend ceiling (confirmed fees plus outstanding reservations)",
+                            );
+                            break;
+                        }
+                        let t_batch = Instant::now();
+                        if pool_mode {
+                            // No barrier: each worker loops independently.
+                            send_one(
+                                &provider,
+                                tx.clone(),
+                                estimate,
+                                overprovision_pct,
+                                send_timeout,
+                                &outcomes,
+                                &samples,
+                                &measuring,
+                                &budget,
+                            )
+                            .await;
+                            done_count.fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            let mut set = tokio::task::JoinSet::new();
+                            for _ in 0..batch {
+                                let provider = provider.clone();
+                                let outcomes = outcomes.clone();
+                                let samples = samples.clone();
+                                let measuring = measuring.clone();
+                                let tx = tx.clone();
+                                let budget = budget.clone();
+                                set.spawn(async move {
+                                    send_one(
+                                        &provider,
+                                        tx,
+                                        estimate,
+                                        overprovision_pct,
+                                        send_timeout,
+                                        &outcomes,
+                                        &samples,
+                                        &measuring,
+                                        &budget,
+                                    )
+                                    .await;
+                                });
+                            }
+                            // The join barrier the operation loop imposes.
+                            while set.join_next().await.is_some() {}
+                            done_count.fetch_add(batch as u64, Ordering::Relaxed);
+                            if measuring.load(Ordering::Relaxed) {
+                                samples
+                                    .batch_ms
+                                    .lock()
+                                    .unwrap()
+                                    .push(t_batch.elapsed().as_secs_f64() * 1000.0);
+                            }
+                        }
+                    }
+                });
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(warmup)).await;
+        samples.clear();
+        let base_done = done_count.load(Ordering::Relaxed);
+        let base_ok = outcomes.ok.load(Ordering::Relaxed);
+        let m_start = Instant::now();
+        measuring.store(true, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_secs(measure)).await;
+        measuring.store(false, Ordering::Relaxed);
+        let measured_ok = outcomes.ok.load(Ordering::Relaxed) - base_ok;
+        let elapsed = m_start.elapsed().as_secs_f64();
+        let completed = done_count.load(Ordering::Relaxed) - base_done;
+        stop.store(true, Ordering::Relaxed);
+        while let Some(result) = loops.join_next().await {
+            result?;
+        }
+
+        let tx_ms = samples.tx_ms.lock().unwrap().clone();
+        let n_ok = outcomes.ok.load(Ordering::Relaxed);
+        let rate = measured_ok as f64 / elapsed;
+        println!("measured successful receipts: {measured_ok}; goodput {rate:.3} tx/s");
+        println!(
+            "\nbatch {batch} x {ops} op(s) x {n_accounts} account(s) = {} concurrent",
+            batch * ops * n_accounts
+        );
+        println!(
+            "  completed {completed} attempts in {elapsed:.1}s  ->  {rate:.2} attempts/s \
+(sampled {} in-window)",
+            tx_ms.len()
+        );
+        summarise("  per-tx total", tx_ms.clone());
+        summarise(
+            "  gas estimate",
+            samples.estimate_ms.lock().unwrap().clone(),
+        );
+        if !pool_mode {
+            summarise(
+                "  batch wall time",
+                samples.batch_ms.lock().unwrap().clone(),
+            );
+        }
+        outcomes.report();
+
+        let mut sorted = tx_ms.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        rows.push(format!(
+            "{batch},{ops},{n_accounts},{},{:.3},{:.1},{:.1},{:.1},{},{},{}",
+            tx_ms.len(),
+            rate,
+            pct(&sorted, 0.50),
+            pct(&sorted, 0.90),
+            pct(&sorted, 0.99),
+            n_ok,
+            outcomes.total_errors(),
+            outcomes.send_timeout.load(Ordering::Relaxed),
+        ));
+
+        // Let everything in flight settle before reading the chain.
+        tokio::time::sleep(Duration::from_secs(8)).await;
+        let mut spent_total = U256::ZERO;
+        for (i, (addr, _)) in wallets.iter().enumerate() {
+            let latest = probe.get_transaction_count(*addr).await?;
+            let pending = probe.get_transaction_count(*addr).pending().await?;
+            anyhow::ensure!(latest == pending, "unmined work at rest; stop campaign");
+            let bal = probe.get_balance(*addr).await?;
+            spent_total += start_balances[i].saturating_sub(bal);
+            println!(
+                "  {addr}: nonce {} -> {latest} (pending {pending}, unmined {})",
+                start_nonces[i],
+                pending.saturating_sub(latest)
+            );
+        }
+        if spent_total > U256::from(ceilings.max_spend_wei) {
+            ceilings.trip(format!("spend ceiling: {spent_total} wei"));
+        }
+        if m_start.elapsed().as_secs() > ceilings.max_secs {
+            ceilings.trip("time ceiling");
+        }
+    }
+
+    println!(
+        "\nbatch,ops,accounts,samples,rate_per_s,p50_ms,p90_ms,p99_ms,ok,errors,send_timeouts"
+    );
+    for r in &rows {
+        println!("{r}");
+    }
+    if let Some(why) = ceilings.reason.lock().unwrap().as_ref() {
+        println!("CEILING TRIPPED: {why}");
+        anyhow::bail!("campaign ceiling tripped");
+    }
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/https_failure_mode_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/https_failure_mode_tests.rs
@@ -1,0 +1,379 @@
+//! Failure modes of the v0.13.4 submission design over HTTP.
+//!
+//! The design allocates a nonce under a brief lock, releases it, then submits
+//! concurrently. Submissions therefore reach the node out of order, and a
+//! failure leaves a gap that later nonces sit behind. These tests drive the
+//! real sender through a fault-injecting proxy in front of Anvil and check what
+//! happens to the work, not just to the transaction.
+
+mod common;
+mod support;
+
+use std::time::Duration;
+
+use alloy::primitives::U256;
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::sol;
+use rand::random;
+use rstest::rstest;
+use serial_test::serial;
+use tokio::time::sleep;
+use transaction_sender::{
+    gateway_http_client, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
+    TransactionSender,
+};
+
+use common::{SignerType, TestEnvironment};
+use support::{Fault, FaultProxy};
+use test_harness::db_utils::{insert_ciphertext_digest, insert_random_keys_and_host_chain};
+
+sol!(
+    #[sol(rpc)]
+    CiphertextCommits,
+    "artifacts/CiphertextCommits.sol/CiphertextCommits.json"
+);
+
+/// Builds the sender's provider pointed at the proxy rather than at Anvil.
+fn provider_via(
+    env: &TestEnvironment,
+    proxy: &FaultProxy,
+) -> anyhow::Result<NonceManagedProvider<alloy::providers::DynProvider>> {
+    use alloy::network::TxSigner as _;
+    let url = proxy.url();
+    let inner = ProviderBuilder::default()
+        .filler(FillersWithoutNonceManagement::default())
+        .wallet(env.wallet.clone())
+        .connect_reqwest(gateway_http_client(&url)?, url)
+        .erased();
+    Ok(NonceManagedProvider::new(inner, Some(env.signer.address())))
+}
+
+/// A submission whose response is lost is an *ambiguous acceptance*: the
+/// transaction is on chain, the caller saw an error. The design resets its
+/// cached nonce on any send error, so the next allocation re-reads the pending
+/// count. This checks that the sequence recovers and no digest is stranded.
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[tokio::test]
+#[serial(db)]
+async fn lost_submission_response_does_not_strand_work(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        add_ciphertexts_batch_limit: 10,
+        add_ciphertexts_max_retries: i32::MAX,
+        graceful_shutdown_timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+    let env = TestEnvironment::new_with_config(signer_type, conf, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+
+    let provider_deploy = env.http_provider()?;
+    let provider = provider_via(&env, &proxy)?;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider_deploy, false).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        alloy::signers::local::PrivateKeySigner::random().address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+    let (host_chain_id, key_id) = insert_random_keys_and_host_chain(&env.db_pool).await?;
+
+    // Lose exactly one submission response. The transaction still executes.
+    proxy.set_fault(
+        "eth_sendRawTransactionSync",
+        Fault::SuppressResponse,
+        Some(1),
+    );
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let handle = random::<[u8; 32]>();
+        insert_ciphertext_digest(
+            &env.db_pool,
+            host_chain_id,
+            key_id,
+            &handle,
+            &random::<[u8; 32]>(),
+            &random::<[u8; 32]>(),
+            1,
+        )
+        .await?;
+        handles.push(handle);
+    }
+    sqlx::query!(
+        "
+        SELECT pg_notify($1, '')",
+        env.conf.add_ciphertexts_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Every digest must end up sent, including the one whose response was lost.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
+    loop {
+        // Runtime-checked: this shape is not in the offline query cache.
+        let pending: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM ciphertext_digest WHERE txn_is_sent = false")
+                .fetch_one(&env.db_pool)
+                .await?;
+        if pending == 0 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{pending} digest(s) still unsent after 90 s"
+        );
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    let signer_addr = {
+        use alloy::network::TxSigner as _;
+        env.signer.address()
+    };
+    let latest = provider_deploy.get_transaction_count(signer_addr).await?;
+    let pending = provider_deploy
+        .get_transaction_count(signer_addr)
+        .pending()
+        .await?;
+    assert_eq!(
+        latest, pending,
+        "the nonce sequence must be gap-free at rest ({pending} pending vs {latest} mined)"
+    );
+
+    env.cancel_token.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), run_handle).await;
+    Ok(())
+}
+
+/// A submission that is simply slow, past the deadline. The design's timeout
+/// abandons the wait while the transaction may still be mined, so the nonce is
+/// consumed. This measures whether the batch loop recovers or stalls behind the
+/// abandoned nonce.
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[tokio::test]
+#[serial(db)]
+async fn submission_past_the_deadline_does_not_stall_the_batch_loop(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        add_ciphertexts_batch_limit: 10,
+        add_ciphertexts_max_retries: i32::MAX,
+        send_txn_sync_timeout_secs: 2,
+        graceful_shutdown_timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+    let env = TestEnvironment::new_with_config(signer_type, conf, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+
+    let provider_deploy = env.http_provider()?;
+    let provider = provider_via(&env, &proxy)?;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider_deploy, false).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        alloy::signers::local::PrivateKeySigner::random().address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+    let (host_chain_id, key_id) = insert_random_keys_and_host_chain(&env.db_pool).await?;
+
+    // Hold two responses past the 2 s deadline; the transactions still land.
+    proxy.set_fault(
+        "eth_sendRawTransactionSync",
+        Fault::DelayResponse(Duration::from_secs(4)),
+        Some(2),
+    );
+
+    for _ in 0..10 {
+        let handle = random::<[u8; 32]>();
+        insert_ciphertext_digest(
+            &env.db_pool,
+            host_chain_id,
+            key_id,
+            &handle,
+            &random::<[u8; 32]>(),
+            &random::<[u8; 32]>(),
+            1,
+        )
+        .await?;
+    }
+    sqlx::query!(
+        "
+        SELECT pg_notify($1, '')",
+        env.conf.add_ciphertexts_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        // Runtime-checked: this shape is not in the offline query cache.
+        let pending: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM ciphertext_digest WHERE txn_is_sent = false")
+                .fetch_one(&env.db_pool)
+                .await?;
+        if pending == 0 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{pending} digest(s) still unsent after 120 s; the loop did not recover"
+        );
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    println!(
+        "sendRawTransactionSync calls seen by the proxy: {}",
+        proxy.calls("eth_sendRawTransactionSync")
+    );
+
+    env.cancel_token.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), run_handle).await;
+    Ok(())
+}
+
+/// Sanity check on the environment itself: the ciphertext balance is untouched,
+/// so a failing assertion above is about the sender, not about funding.
+#[tokio::test]
+async fn proxy_forwards_normally_when_no_fault_is_set() -> anyhow::Result<()> {
+    let anvil = alloy::node_bindings::Anvil::new().try_spawn()?;
+    let proxy = FaultProxy::start(anvil.endpoint_url()).await?;
+    let url = proxy.url();
+    let provider = ProviderBuilder::new().connect_reqwest(gateway_http_client(&url)?, url);
+    assert_eq!(provider.get_chain_id().await?, anvil.chain_id());
+    assert!(provider.get_balance(anvil.addresses()[0]).await? > U256::ZERO);
+    assert_eq!(proxy.calls("eth_chainId"), 1);
+    Ok(())
+}
+
+/// A Gateway that is slow rather than absent.
+///
+/// The `Queue` fault serves matching requests through one channel, so latency
+/// grows with concurrency — the same shape that made the WebSocket transport
+/// fail, but applied to the endpoint itself. At a 200 ms service time and ten
+/// concurrent submissions the last one waits 2 s, so a 4 s deadline holds and a
+/// 1 s deadline does not. This checks which way the work goes when it does not.
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[tokio::test]
+#[serial(db)]
+async fn a_congested_gateway_retries_rather_than_loses_ciphertext_work(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        add_ciphertexts_batch_limit: 10,
+        add_ciphertexts_max_retries: i32::MAX,
+        // Deliberately too short for the congestion injected below.
+        send_txn_sync_timeout_secs: 1,
+        graceful_shutdown_timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+    let env = TestEnvironment::new_with_config(signer_type, conf, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+
+    let provider_deploy = env.http_provider()?;
+    let provider = provider_via(&env, &proxy)?;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider_deploy, false).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        alloy::signers::local::PrivateKeySigner::random().address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+    let (host_chain_id, key_id) = insert_random_keys_and_host_chain(&env.db_pool).await?;
+
+    // Congest submission: one channel, 300 ms each. Ten concurrent submissions
+    // therefore finish between 0.3 s and 3 s, straddling the 1 s deadline.
+    proxy.set_fault(
+        "eth_sendRawTransactionSync",
+        Fault::Queue {
+            service: Duration::from_millis(300),
+        },
+        None,
+    );
+
+    for _ in 0..10 {
+        let handle = random::<[u8; 32]>();
+        insert_ciphertext_digest(
+            &env.db_pool,
+            host_chain_id,
+            key_id,
+            &handle,
+            &random::<[u8; 32]>(),
+            &random::<[u8; 32]>(),
+            1,
+        )
+        .await?;
+    }
+    sqlx::query!(
+        "
+        SELECT pg_notify($1, '')",
+        env.conf.add_ciphertexts_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Let the congested phase run, then relieve it.
+    sleep(Duration::from_secs(12)).await;
+    let during = proxy.calls("eth_sendRawTransactionSync");
+    proxy.clear_all_faults();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
+    loop {
+        let pending: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM ciphertext_digest WHERE txn_is_sent = false")
+                .fetch_one(&env.db_pool)
+                .await?;
+        if pending == 0 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{pending} digest(s) still unsent 90 s after congestion cleared"
+        );
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    let unlimited: i32 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(txn_unlimited_retries_count), 0) FROM ciphertext_digest",
+    )
+    .fetch_one(&env.db_pool)
+    .await?;
+    let limited: i32 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(txn_limited_retries_count), 0) FROM ciphertext_digest",
+    )
+    .fetch_one(&env.db_pool)
+    .await?;
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ciphertext_digest")
+        .fetch_one(&env.db_pool)
+        .await?;
+
+    println!(
+        "congested Gateway: {during} submissions attempted while congested; \
+all {total} digests sent; max limited retries {limited}, max unlimited retries {unlimited}"
+    );
+    assert_eq!(total, 10, "no digest may be dropped by congestion");
+
+    env.cancel_token.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), run_handle).await;
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/https_transport_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/https_transport_tests.rs
@@ -1,0 +1,152 @@
+//! Transport-only change: the Gateway endpoint moved from WebSocket to HTTP.
+//!
+//! These cover the parts of that move that are not visible in the submission
+//! path: URL validation, the client policy, and the fact that inclusion is
+//! still awaited by the node rather than polled by the client.
+
+use transaction_sender::gateway_http_client;
+
+/// A leftover `wss://` value must fail immediately, not be silently rewritten
+/// and not be retried forever.
+#[test]
+fn websocket_urls_are_rejected_rather_than_rewritten() {
+    for url in ["wss://gateway.invalid/rpc", "ws://gateway.invalid/rpc"] {
+        let parsed: alloy::transports::http::reqwest::Url = url.parse().expect("url");
+        let err = gateway_http_client(&parsed).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("http:// or https://"),
+            "error should name the requirement, got: {msg}"
+        );
+        assert!(
+            !msg.contains("https://gateway.invalid"),
+            "the URL must not be rewritten for the caller: {msg}"
+        );
+    }
+}
+
+#[test]
+fn http_and_https_urls_are_accepted() {
+    for url in ["http://gateway.invalid/rpc", "https://gateway.invalid/rpc"] {
+        let parsed: alloy::transports::http::reqwest::Url = url.parse().expect("url");
+        gateway_http_client(&parsed).expect("must accept");
+    }
+}
+
+/// The submission path must not inherit a transport-level retry: a retried
+/// `eth_sendRawTransactionSync` is indistinguishable from a duplicate send, and
+/// the operation retry loop already owns recovery.
+#[tokio::test]
+async fn submission_is_not_retried_by_the_transport() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let hits = Arc::new(AtomicUsize::new(0));
+    let seen = hits.clone();
+    let app = axum::Router::new().route(
+        "/",
+        axum::routing::post(move || {
+            let seen = seen.clone();
+            async move {
+                seen.fetch_add(1, Ordering::SeqCst);
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "upstream exploded",
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let url: alloy::transports::http::reqwest::Url =
+        format!("http://{addr}/").parse().expect("url");
+    let client = gateway_http_client(&url).expect("client");
+    let res = client.post(url).body("{}").send().await.expect("response");
+
+    assert_eq!(res.status().as_u16(), 500);
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "the failed request must reach the server exactly once"
+    );
+}
+
+/// A redirect must not be followed: it would resend the signed transaction to
+/// a host the operator did not configure.
+#[tokio::test]
+async fn redirects_are_not_followed() {
+    let app = axum::Router::new()
+        .route(
+            "/",
+            axum::routing::post(|| async {
+                (
+                    axum::http::StatusCode::TEMPORARY_REDIRECT,
+                    [(axum::http::header::LOCATION, "/elsewhere")],
+                    "",
+                )
+            }),
+        )
+        .route("/elsewhere", axum::routing::post(|| async { "reached" }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let url: alloy::transports::http::reqwest::Url =
+        format!("http://{addr}/").parse().expect("url");
+    let client = gateway_http_client(&url).expect("client");
+    let res = client.post(url).body("{}").send().await.expect("response");
+    assert_eq!(
+        res.status().as_u16(),
+        307,
+        "the redirect must not be followed"
+    );
+}
+
+/// Every non-HTTP scheme is refused, and the message names what is required
+/// rather than what was given — the Gateway URL carries an auth token on this
+/// endpoint, so it must not be echoed.
+#[test]
+fn non_http_schemes_are_refused_without_echoing_the_url() {
+    for url in [
+        "ws://gateway.invalid/rpc/SECRET",
+        "wss://gateway.invalid/rpc/SECRET",
+        "file:///tmp/socket",
+        "ipc:///tmp/geth.ipc",
+    ] {
+        let parsed = url
+            .parse::<alloy::transports::http::reqwest::Url>()
+            .expect("valid fixture URL");
+        let err = gateway_http_client(&parsed)
+            .expect_err("only http and https may be accepted")
+            .to_string();
+        assert!(
+            err.contains("http:// or https://"),
+            "the error must name the requirement, got: {err}"
+        );
+        assert!(
+            !err.contains("SECRET"),
+            "the error must not echo the URL, got: {err}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn public_chain_id_probe_returns_configuration_errors_without_panicking() {
+    let error = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        transaction_sender::get_chain_id(
+            "wss://gateway.invalid/SECRET".parse().unwrap(),
+            std::time::Duration::from_secs(4),
+        ),
+    )
+    .await
+    .expect("invalid scheme must not be retried")
+    .expect_err("invalid scheme must return an error");
+    assert!(!format!("{error:?}").contains("SECRET"));
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/https_transport_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/https_transport_tests.rs
@@ -150,3 +150,31 @@ async fn public_chain_id_probe_returns_configuration_errors_without_panicking() 
     .expect_err("invalid scheme must return an error");
     assert!(!format!("{error:?}").contains("SECRET"));
 }
+
+#[test]
+fn binary_configuration_errors_do_not_echo_gateway_credentials() {
+    for url in [
+        "https://user:SECRET@gateway.invalid:invalid/SECRET",
+        "wss://user:SECRET@gateway.invalid/SECRET",
+    ] {
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_transaction_sender"))
+            .args([
+                "--gateway-url",
+                url,
+                "--input-verification-address",
+                "0x0000000000000000000000000000000000000001",
+                "--ciphertext-commits-address",
+                "0x0000000000000000000000000000000000000002",
+            ])
+            .output()
+            .expect("run sender binary");
+        assert!(!output.status.success());
+        for bytes in [&output.stdout, &output.stderr] {
+            assert!(
+                !String::from_utf8_lossy(bytes).contains("SECRET"),
+                "startup leaked credentials"
+            );
+        }
+        assert!(String::from_utf8_lossy(&output.stderr).contains("Gateway URL"));
+    }
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/overprovision_gas_limit_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/overprovision_gas_limit_tests.rs
@@ -1,12 +1,11 @@
 mod common;
 
 use alloy::primitives::{FixedBytes, U256};
-use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::providers::Provider;
 use common::SignerType;
 use common::{CiphertextCommits, TestEnvironment};
 use rstest::*;
 use serial_test::serial;
-use std::time::Duration;
 use transaction_sender::NonceManagedProvider;
 
 #[rstest]
@@ -17,10 +16,7 @@ use transaction_sender::NonceManagedProvider;
 async fn overprovision_gas_limit(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::new()
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_provider()?,
         Some(env.wallet.default_signer().address()),
     );
 
@@ -66,15 +62,7 @@ async fn overprovision_gas_limit(#[case] signer_type: SignerType) -> anyhow::Res
 async fn overprovision_estimate_failure(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let mut env = TestEnvironment::new(signer_type).await?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::new()
-            .wallet(env.wallet.clone())
-            .connect_ws(
-                // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
-                WsConnect::new(env.ws_endpoint_url())
-                    .with_max_retries(2)
-                    .with_retry_interval(Duration::from_millis(100)),
-            )
-            .await?,
+        env.http_provider()?,
         Some(env.wallet.default_signer().address()),
     );
 

--- a/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
@@ -1,0 +1,491 @@
+//! Method-aware JSON-RPC fault proxy for the transaction-sender hotfix
+//! validation (see `docs/minimal-v013-hotfix-plan.md`).
+//!
+//! Sits between a provider and anvil, counts calls per method, and can delay,
+//! blackhole, or suppress the response of individual methods. This is what the
+//! plan's "method-aware RPC fault proxy" refers to: the regression cases need to
+//! stall `eth_getTransactionCount(pending)` while every other RPC stays healthy,
+//! and to count `eth_estimateGas` per attempt.
+//!
+//! Deliberately dependency-free: built on `axum` and the `reqwest` re-exported
+//! by alloy, both already in the crate's dependency graph, so `--locked` runs
+//! and the release lockfile are unaffected.
+//!
+//! Transport note: production now uses HTTP/HTTPS. This proxy exercises the
+//! same RPC transport class, but does not establish TLS, load-balancer or Nitro
+//! behavior. Explicit WS tests remain library-only historical compatibility tests.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use alloy::transports::http::reqwest;
+use axum::{body::Bytes, extract::State, routing::post, Router};
+use serde_json::Value;
+
+/// What the proxy does with a matching request.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Fault {
+    /// Park the request and never answer it, until the fault is cleared (then
+    /// the parked request is forwarded normally). Models a blackholed RPC.
+    Blackhole,
+    /// Forward, but only after this delay.
+    Delay(Duration),
+    /// Forward upstream so the call really executes, then discard the response.
+    /// Models an accepted transaction whose success response is lost.
+    SuppressResponse,
+    /// Serve matching requests through a single service channel, each taking
+    /// `service` time. Latency therefore grows with concurrency, which is how a
+    /// single shared WS provider actually behaves: the incident's 0.05 s -> 5-6 s
+    /// p50 "prep" inflation came from 128 concurrent `eth_estimateGas` calls
+    /// queuing on one connection, not from a flat per-call delay. A flat delay
+    /// rewards unbounded concurrency and so cannot reproduce the failure.
+    Queue { service: Duration },
+    /// Answer with this JSON-RPC `result` without forwarding upstream. Used to
+    /// inject a stale `eth_getTransactionCount`, which the node would otherwise
+    /// never return.
+    RespondWith(Value),
+    /// Forward upstream and wait for the real answer, then hold it for this long
+    /// before replying. For `eth_sendRawTransactionSync` the upstream answer
+    /// only arrives once the transaction is mined, so this guarantees the
+    /// transaction is on-chain while the caller is still waiting - which is what
+    /// makes the "cancelled sibling leaves on-chain work with no DB record"
+    /// scenario deterministic rather than a race.
+    DelayResponse(Duration),
+}
+
+#[derive(Clone, Debug)]
+struct FaultSpec {
+    fault: Fault,
+    /// Remaining applications; `None` means unlimited.
+    remaining: Option<usize>,
+}
+
+#[derive(Default, Debug)]
+struct Stats {
+    calls: HashMap<String, usize>,
+    /// `eth_getTransactionCount` split by its block-tag parameter.
+    tx_count_by_tag: HashMap<String, usize>,
+    /// Observed handling latency per method, in milliseconds.
+    latencies: HashMap<String, Vec<u64>>,
+    /// Error strings seen in upstream *responses*, counted as events.
+    /// A database `last_error` column is overwritten by the next error and
+    /// erased by cleanup, so it cannot be used to count occurrences; this can.
+    response_errors: HashMap<String, usize>,
+    in_flight: HashMap<String, usize>,
+    max_in_flight: HashMap<String, usize>,
+}
+
+#[derive(Default, Debug)]
+struct Inner {
+    faults: HashMap<String, FaultSpec>,
+    stats: Stats,
+}
+
+/// Per-method single service channel, for `Fault::Queue`.
+#[derive(Default)]
+struct Queues {
+    channels: HashMap<String, Arc<tokio::sync::Mutex<()>>>,
+}
+
+struct Shared {
+    inner: Mutex<Inner>,
+    upstream: String,
+    client: reqwest::Client,
+    queues: Mutex<Queues>,
+}
+
+pub struct FaultProxy {
+    shared: Arc<Shared>,
+    url: reqwest::Url,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+/// Safety valve: a blackholed request is dropped rather than parked forever, so
+/// a mistake in a test surfaces as a failure instead of a hang.
+const MAX_PARK: Duration = Duration::from_secs(180);
+
+impl FaultProxy {
+    /// Starts a proxy in front of `upstream_http` (anvil's HTTP endpoint).
+    pub async fn start(upstream_http: reqwest::Url) -> anyhow::Result<Self> {
+        let shared = Arc::new(Shared {
+            inner: Mutex::new(Inner::default()),
+            queues: Mutex::new(Queues::default()),
+            upstream: upstream_http.to_string(),
+            client: reqwest::Client::builder()
+                // The proxy must not impose its own deadline: the point is to
+                // let the *client's* timeout fire.
+                .timeout(Duration::from_secs(600))
+                .build()?,
+        });
+
+        let app = Router::new()
+            .route("/", post(handle))
+            .with_state(shared.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await;
+        });
+
+        Ok(Self {
+            shared,
+            url: reqwest::Url::parse(&format!("http://127.0.0.1:{port}/"))?,
+            shutdown: Some(tx),
+        })
+    }
+
+    pub fn url(&self) -> reqwest::Url {
+        self.url.clone()
+    }
+
+    /// Applies `fault` to `method`. `remaining = None` means until cleared.
+    pub fn set_fault(&self, method: &str, fault: Fault, remaining: Option<usize>) {
+        self.shared
+            .inner
+            .lock()
+            .unwrap()
+            .faults
+            .insert(method.to_string(), FaultSpec { fault, remaining });
+    }
+
+    pub fn clear_fault(&self, method: &str) {
+        self.shared.inner.lock().unwrap().faults.remove(method);
+    }
+
+    pub fn clear_all_faults(&self) {
+        self.shared.inner.lock().unwrap().faults.clear();
+    }
+
+    pub fn calls(&self, method: &str) -> usize {
+        *self
+            .shared
+            .inner
+            .lock()
+            .unwrap()
+            .stats
+            .calls
+            .get(method)
+            .unwrap_or(&0)
+    }
+
+    /// `eth_getTransactionCount` calls made with the given block tag.
+    pub fn tx_count_calls_with_tag(&self, tag: &str) -> usize {
+        *self
+            .shared
+            .inner
+            .lock()
+            .unwrap()
+            .stats
+            .tx_count_by_tag
+            .get(tag)
+            .unwrap_or(&0)
+    }
+
+    /// Peak observed concurrency for a method, for the admission-limit check.
+    pub fn max_concurrency(&self, method: &str) -> usize {
+        *self
+            .shared
+            .inner
+            .lock()
+            .unwrap()
+            .stats
+            .max_in_flight
+            .get(method)
+            .unwrap_or(&0)
+    }
+
+    /// Observed latency percentile for a method, in milliseconds. This is the
+    /// plan's "prep latency" proxy measurement: the time the sender waits for
+    /// `eth_estimateGas`, measured at the proxy rather than from log brackets.
+    pub fn latency_pct(&self, method: &str, pct: f64) -> u64 {
+        let inner = self.shared.inner.lock().unwrap();
+        let Some(v) = inner.stats.latencies.get(method) else {
+            return 0;
+        };
+        if v.is_empty() {
+            return 0;
+        }
+        let mut v = v.clone();
+        v.sort_unstable();
+        let idx = ((v.len() as f64 - 1.0) * pct).round() as usize;
+        v[idx]
+    }
+
+    pub fn latency_count(&self, method: &str) -> usize {
+        self.shared
+            .inner
+            .lock()
+            .unwrap()
+            .stats
+            .latencies
+            .get(method)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+
+    /// Number of upstream responses containing `needle` (case-insensitive).
+    pub fn response_errors(&self, needle: &str) -> usize {
+        *self
+            .shared
+            .inner
+            .lock()
+            .unwrap()
+            .stats
+            .response_errors
+            .get(&needle.to_lowercase())
+            .unwrap_or(&0)
+    }
+
+    /// Clears only the latency samples, so percentiles can be reported per
+    /// phase instead of mixing a fault window with the recovery that follows.
+    pub fn reset_latencies(&self) {
+        self.shared.inner.lock().unwrap().stats.latencies.clear();
+    }
+
+    pub fn reset_stats(&self) {
+        self.shared.inner.lock().unwrap().stats = Stats::default();
+    }
+
+    pub fn snapshot(&self) -> HashMap<String, usize> {
+        self.shared.inner.lock().unwrap().stats.calls.clone()
+    }
+}
+
+impl Drop for FaultProxy {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Pulls the method name out of a single or batched JSON-RPC body.
+fn methods_of(body: &Value) -> Vec<String> {
+    match body {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|i| i.get("method").and_then(|m| m.as_str()).map(String::from))
+            .collect(),
+        other => other
+            .get("method")
+            .and_then(|m| m.as_str())
+            .map(|m| vec![m.to_string()])
+            .unwrap_or_default(),
+    }
+}
+
+/// Block tag of an `eth_getTransactionCount` call, e.g. `pending` / `latest`.
+fn tx_count_tag(body: &Value) -> Option<String> {
+    let params = body.get("params")?.as_array()?;
+    match params.get(1) {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(other) => Some(other.to_string()),
+        // Omitted tag defaults to `latest` per the JSON-RPC spec.
+        None => Some("latest".to_string()),
+    }
+}
+
+fn record_start(shared: &Shared, methods: &[String], body: &Value) {
+    let mut inner = shared.inner.lock().unwrap();
+    for m in methods {
+        *inner.stats.calls.entry(m.clone()).or_insert(0) += 1;
+        let n = inner.stats.in_flight.entry(m.clone()).or_insert(0);
+        *n += 1;
+        let n = *n;
+        let peak = inner.stats.max_in_flight.entry(m.clone()).or_insert(0);
+        if n > *peak {
+            *peak = n;
+        }
+        if m == "eth_getTransactionCount" {
+            if let Some(tag) = tx_count_tag(body) {
+                *inner.stats.tx_count_by_tag.entry(tag).or_insert(0) += 1;
+            }
+        }
+    }
+}
+
+fn record_end(shared: &Shared, methods: &[String], elapsed_ms: u64) {
+    let mut inner = shared.inner.lock().unwrap();
+    for m in methods {
+        if let Some(n) = inner.stats.in_flight.get_mut(m) {
+            *n = n.saturating_sub(1);
+        }
+        inner
+            .stats
+            .latencies
+            .entry(m.clone())
+            .or_default()
+            .push(elapsed_ms);
+    }
+}
+
+/// Takes the fault to apply, consuming one unit of its budget.
+fn take_fault(shared: &Shared, methods: &[String]) -> Option<Fault> {
+    let mut inner = shared.inner.lock().unwrap();
+    for m in methods {
+        let Some(spec) = inner.faults.get_mut(m) else {
+            continue;
+        };
+        match &mut spec.remaining {
+            Some(0) => continue,
+            Some(n) => *n -= 1,
+            None => {}
+        }
+        return Some(spec.fault.clone());
+    }
+    None
+}
+
+/// True while `method` still has an active blackhole.
+fn blackhole_active(shared: &Shared, methods: &[String]) -> bool {
+    let inner = shared.inner.lock().unwrap();
+    methods.iter().any(|m| {
+        matches!(
+            inner.faults.get(m),
+            Some(FaultSpec {
+                fault: Fault::Blackhole,
+                ..
+            })
+        )
+    })
+}
+
+async fn handle(State(shared): State<Arc<Shared>>, body: Bytes) -> axum::response::Response {
+    let began = std::time::Instant::now();
+    let parsed: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    let methods = methods_of(&parsed);
+    record_start(&shared, &methods, &parsed);
+
+    let fault = take_fault(&shared, &methods);
+    let mut suppress = false;
+    let mut hold_response = None;
+
+    match fault {
+        Some(Fault::Delay(d)) => tokio::time::sleep(d).await,
+        Some(Fault::SuppressResponse) => suppress = true,
+        Some(Fault::DelayResponse(d)) => hold_response = Some(d),
+        Some(Fault::RespondWith(value)) => {
+            use axum::response::IntoResponse;
+            let id = parsed.get("id").cloned().unwrap_or(Value::Null);
+            let body = serde_json::json!({"jsonrpc": "2.0", "id": id, "result": value});
+            record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+            return (
+                axum::http::StatusCode::OK,
+                [("content-type", "application/json")],
+                serde_json::to_vec(&body).unwrap_or_default(),
+            )
+                .into_response();
+        }
+        Some(Fault::Queue { service }) => {
+            // One service channel per method: concurrent callers queue, so the
+            // observed latency is proportional to how many are in flight.
+            let channel = {
+                let mut q = shared.queues.lock().unwrap();
+                q.channels
+                    .entry(methods.first().cloned().unwrap_or_default())
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone()
+            };
+            let _slot = channel.lock().await;
+            tokio::time::sleep(service).await;
+        }
+        Some(Fault::Blackhole) => {
+            // Park until the fault is lifted, then fall through and forward.
+            let deadline = tokio::time::Instant::now() + MAX_PARK;
+            while blackhole_active(&shared, &methods) {
+                if tokio::time::Instant::now() >= deadline {
+                    record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+                    // Give up rather than hang the test forever.
+                    return (axum::http::StatusCode::GATEWAY_TIMEOUT, "proxy park cap")
+                        .into_response();
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+        None => {}
+    }
+
+    let upstream = shared
+        .client
+        .post(&shared.upstream)
+        .header("content-type", "application/json")
+        .body(body.clone())
+        .send()
+        .await;
+
+    record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+
+    use axum::response::IntoResponse;
+    match upstream {
+        Ok(resp) => {
+            let status = resp.status();
+            let bytes = resp.bytes().await.unwrap_or_default();
+            record_response_errors(&shared, &bytes);
+            if suppress {
+                // The call executed upstream; the caller never learns the result.
+                return futures_pending().await;
+            }
+            if let Some(d) = hold_response {
+                // Upstream already applied the call; only the answer is late.
+                tokio::time::sleep(d).await;
+            }
+            (
+                axum::http::StatusCode::from_u16(status.as_u16())
+                    .unwrap_or(axum::http::StatusCode::OK),
+                [("content-type", "application/json")],
+                bytes,
+            )
+                .into_response()
+        }
+        Err(e) => (
+            axum::http::StatusCode::BAD_GATEWAY,
+            format!("proxy upstream error: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+/// Error strings worth counting as events when they appear in a response.
+const COUNTED_RESPONSE_ERRORS: [&str; 5] = [
+    "nonce too low",
+    "nonce too high",
+    "already known",
+    "replacement transaction underpriced",
+    "insufficient funds",
+];
+
+fn record_response_errors(shared: &Shared, body: &[u8]) {
+    let text = String::from_utf8_lossy(body).to_lowercase();
+    if !text.contains("error") {
+        return;
+    }
+    let mut inner = shared.inner.lock().unwrap();
+    for needle in COUNTED_RESPONSE_ERRORS {
+        if text.contains(needle) {
+            *inner
+                .stats
+                .response_errors
+                .entry(needle.to_string())
+                .or_insert(0) += 1;
+        }
+    }
+}
+
+/// Never resolves: the client must hit its own timeout.
+async fn futures_pending() -> axum::response::Response {
+    tokio::time::sleep(MAX_PARK).await;
+    use axum::response::IntoResponse;
+    (
+        axum::http::StatusCode::GATEWAY_TIMEOUT,
+        "proxy suppressed response",
+    )
+        .into_response()
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
@@ -28,6 +28,13 @@ use serde_json::Value;
 /// What the proxy does with a matching request.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fault {
+    /// Fail before forwarding, leaving upstream chain state untouched.
+    HttpError(u16),
+    /// Return an RPC error before forwarding, with the caller's request ID.
+    RpcError { code: i64, message: String },
+    /// Let the caller's deadline expire, then discard this request permanently.
+    /// Unlike Blackhole, clearing the fault never forwards an old request.
+    DiscardAfter(Duration),
     /// Park the request and never answer it, until the fault is cleared (then
     /// the parked request is forwarded normally). Models a blackholed RPC.
     Blackhole,
@@ -369,6 +376,30 @@ async fn handle(State(shared): State<Arc<Shared>>, body: Bytes) -> axum::respons
     let mut hold_response = None;
 
     match fault {
+        Some(Fault::HttpError(status)) => {
+            use axum::response::IntoResponse;
+            record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+            return (
+                axum::http::StatusCode::from_u16(status).unwrap(),
+                "injected failure",
+            )
+                .into_response();
+        }
+        Some(Fault::RpcError { code, message }) => {
+            use axum::response::IntoResponse;
+            let body = serde_json::json!({
+                "jsonrpc": "2.0", "id": parsed.get("id"),
+                "error": { "code": code, "message": message },
+            });
+            record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+            return axum::Json(body).into_response();
+        }
+        Some(Fault::DiscardAfter(delay)) => {
+            use axum::response::IntoResponse;
+            tokio::time::sleep(delay).await;
+            record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+            return axum::http::StatusCode::GATEWAY_TIMEOUT.into_response();
+        }
         Some(Fault::Delay(d)) => tokio::time::sleep(d).await,
         Some(Fault::SuppressResponse) => suppress = true,
         Some(Fault::DelayResponse(d)) => hold_response = Some(d),

--- a/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
@@ -28,6 +28,8 @@ use serde_json::Value;
 /// What the proxy does with a matching request.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fault {
+    /// Close the HTTP response body with an I/O error without forwarding.
+    DisconnectBeforeForward,
     /// Arbitrary body for testing echoed credentials and invalid JSON.
     RawResponse { status: u16, body: String },
     /// Fail before forwarding, leaving upstream chain state untouched.
@@ -70,6 +72,7 @@ struct FaultSpec {
     fault: Fault,
     /// Remaining applications; `None` means unlimited.
     remaining: Option<usize>,
+    proof_id_max: Option<u64>,
 }
 
 #[derive(Default, Debug)]
@@ -158,12 +161,26 @@ impl FaultProxy {
 
     /// Applies `fault` to `method`. `remaining = None` means until cleared.
     pub fn set_fault(&self, method: &str, fault: Fault, remaining: Option<usize>) {
-        self.shared
-            .inner
-            .lock()
-            .unwrap()
-            .faults
-            .insert(method.to_string(), FaultSpec { fault, remaining });
+        self.shared.inner.lock().unwrap().faults.insert(
+            method.to_string(),
+            FaultSpec {
+                fault,
+                remaining,
+                proof_id_max: None,
+            },
+        );
+    }
+
+    /// Restrict estimation faults to proof IDs in the earliest batch.
+    pub fn set_early_proof_fault(&self, max_id: u64) {
+        self.shared.inner.lock().unwrap().faults.insert(
+            "eth_estimateGas".into(),
+            FaultSpec {
+                fault: Fault::HttpError(503),
+                remaining: None,
+                proof_id_max: Some(max_id),
+            },
+        );
     }
 
     pub fn clear_fault(&self, method: &str) {
@@ -338,12 +355,27 @@ fn record_end(shared: &Shared, methods: &[String], elapsed_ms: u64) {
 }
 
 /// Takes the fault to apply, consuming one unit of its budget.
-fn take_fault(shared: &Shared, methods: &[String]) -> Option<Fault> {
+fn take_fault(shared: &Shared, methods: &[String], body: &Value) -> Option<Fault> {
     let mut inner = shared.inner.lock().unwrap();
     for m in methods {
         let Some(spec) = inner.faults.get_mut(m) else {
             continue;
         };
+        if let Some(max_id) = spec.proof_id_max {
+            let tx = &body["params"][0];
+            let data = tx
+                .get("input")
+                .or_else(|| tx.get("data"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            // ABI first argument follows the four-byte function selector.
+            let id = data
+                .get(10..74)
+                .and_then(|word| u64::from_str_radix(word.trim_start_matches('0'), 16).ok());
+            if !matches!(id, Some(id) if id > 0 && id <= max_id) {
+                continue;
+            }
+        }
         match &mut spec.remaining {
             Some(0) => continue,
             Some(n) => *n -= 1,
@@ -374,11 +406,21 @@ async fn handle(State(shared): State<Arc<Shared>>, body: Bytes) -> axum::respons
     let methods = methods_of(&parsed);
     record_start(&shared, &methods, &parsed);
 
-    let fault = take_fault(&shared, &methods);
+    let fault = take_fault(&shared, &methods, &parsed);
     let mut suppress = false;
     let mut hold_response = None;
 
     match fault {
+        Some(Fault::DisconnectBeforeForward) => {
+            record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+            let stream = futures_util::stream::once(async {
+                Err::<Bytes, std::io::Error>(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "injected disconnect",
+                ))
+            });
+            return axum::response::Response::new(axum::body::Body::from_stream(stream));
+        }
         Some(Fault::RawResponse { status, mut body }) => {
             use axum::response::IntoResponse;
             if let Ok(mut response) = serde_json::from_str::<Value>(&body) {

--- a/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs
@@ -28,6 +28,8 @@ use serde_json::Value;
 /// What the proxy does with a matching request.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fault {
+    /// Arbitrary body for testing echoed credentials and invalid JSON.
+    RawResponse { status: u16, body: String },
     /// Fail before forwarding, leaving upstream chain state untouched.
     HttpError(u16),
     /// Return an RPC error before forwarding, with the caller's request ID.
@@ -130,6 +132,7 @@ impl FaultProxy {
 
         let app = Router::new()
             .route("/", post(handle))
+            .fallback(handle)
             .with_state(shared.clone());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
         let port = listener.local_addr()?.port();
@@ -376,6 +379,17 @@ async fn handle(State(shared): State<Arc<Shared>>, body: Bytes) -> axum::respons
     let mut hold_response = None;
 
     match fault {
+        Some(Fault::RawResponse { status, mut body }) => {
+            use axum::response::IntoResponse;
+            if let Ok(mut response) = serde_json::from_str::<Value>(&body) {
+                if response.get("jsonrpc").is_some() {
+                    response["id"] = parsed.get("id").cloned().unwrap_or(Value::Null);
+                    body = response.to_string();
+                }
+            }
+            record_end(&shared, &methods, began.elapsed().as_millis() as u64);
+            return (axum::http::StatusCode::from_u16(status).unwrap(), body).into_response();
+        }
         Some(Fault::HttpError(status)) => {
             use axum::response::IntoResponse;
             record_end(&shared, &methods, began.elapsed().as_millis() as u64);

--- a/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
@@ -1532,30 +1532,22 @@ async fn stop_retrying_verify_proof_on_gw_config_error(
     Ok(())
 }
 
-/// What a Gateway outage costs a proof over HTTP.
-///
-/// `verify_proof` has no unlimited-retry path: every send failure increments
-/// `retry_count`, and the selection query drops rows at
-/// `verify_proof_resp_max_retries`. Over WebSocket that budget was protected by
-/// `BackendGone`, which stopped the sender outright on a dead endpoint. Over
-/// HTTP no such signal exists, so the operation loop keeps cycling against the
-/// dead Gateway and spends the budget — with
-/// `verify_proof_remove_after_max_retries` the proof is then deleted.
-///
-/// This test measures how long that takes with the shipped backoff.
+/// A refused HTTP connection must not consume the proof retry budget. Observe
+/// more failures than the budget permits so an idle sender cannot pass.
 #[rstest]
 #[case::private_key(SignerType::PrivateKey)]
 #[tokio::test]
 #[serial(db)]
-async fn gateway_outage_burns_verify_proof_retries(
+async fn gateway_outage_preserves_verify_proof_retries(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let conf = ConfigSettings {
-        verify_proof_resp_max_retries: 6,
+        verify_proof_resp_max_retries: 3,
         verify_proof_remove_after_max_retries: true,
         error_sleep_initial_secs: 1,
         error_sleep_max_secs: 4,
-        graceful_shutdown_timeout: Duration::from_secs(2),
+        // Allow the existing maximum 4-second operation backoff to finish.
+        graceful_shutdown_timeout: Duration::from_secs(5),
         ..Default::default()
     };
     let mut env = TestEnvironment::new_with_config(signer_type, conf.clone(), false).await?;
@@ -1579,6 +1571,16 @@ async fn gateway_outage_burns_verify_proof_retries(
     )
     .await?;
 
+    let failure_count = || {
+        prometheus::gather()
+            .iter()
+            .filter(|family| family.name() == "coprocessor_txn_sender_verify_proof_fail_counter")
+            .flat_map(|family| family.get_metric())
+            .filter_map(|metric| metric.get_counter().as_ref())
+            .map(|counter| counter.value() as u64)
+            .sum::<u64>()
+    };
+    let initial_failures = failure_count();
     let proof_id: u32 = random();
     let run_handle = tokio::spawn(async move { txn_sender.run().await });
 
@@ -1601,45 +1603,30 @@ async fn gateway_outage_burns_verify_proof_retries(
     .execute(&env.db_pool)
     .await?;
 
-    let started = tokio::time::Instant::now();
-    let mut last_retry_count = 0i32;
-    let mut gone_after = None;
-    while started.elapsed() < Duration::from_secs(120) {
-        let rows = sqlx::query!(
-            "SELECT retry_count, last_error
-             FROM verify_proofs
-             WHERE zk_proof_id = $1",
-            proof_id as i64,
-        )
-        .fetch_all(&env.db_pool)
-        .await?;
-        match rows.first() {
-            Some(r) => last_retry_count = r.retry_count,
-            None => {
-                gone_after = Some(started.elapsed());
-                break;
-            }
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let retry_count: Option<i32> =
+            sqlx::query_scalar("SELECT retry_count FROM verify_proofs WHERE zk_proof_id = $1")
+                .bind(proof_id as i64)
+                .fetch_optional(&env.db_pool)
+                .await?;
+        assert_eq!(retry_count, Some(0), "outage must preserve eligibility");
+        assert!(
+            !run_handle.is_finished(),
+            "HTTP retries should stay in the operation loop"
+        );
+        if failure_count() - initial_failures > conf.verify_proof_resp_max_retries as u64 {
+            break;
         }
-        sleep(Duration::from_millis(200)).await;
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "sender did not exercise enough failures"
+        );
+        sleep(Duration::from_millis(100)).await;
     }
 
-    println!(
-        "verify_proof under a dead Gateway over HTTP: last observed retry_count={last_retry_count}, \
-row removed after {:?}",
-        gone_after
-    );
-    assert!(
-        gone_after.is_some(),
-        "the proof survived 120 s of outage with retry_count={last_retry_count}; \
-if this now holds, the retry budget is no longer being spent on transport failures"
-    );
-    assert!(
-        !run_handle.is_finished(),
-        "the sender kept running while it discarded the proof"
-    );
-
     env.cancel_token.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(10), run_handle).await;
+    tokio::time::timeout(Duration::from_secs(10), run_handle).await???;
     Ok(())
 }
 

--- a/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
@@ -1,8 +1,8 @@
 use alloy::network::TxSigner;
 use alloy::primitives::FixedBytes;
 use alloy::primitives::U256;
-use alloy::providers::{Provider, WsConnect};
-use alloy::{providers::ProviderBuilder, sol};
+use alloy::providers::Provider;
+use alloy::sol;
 use common::SignerType;
 use common::{is_coprocessor_config_error, CiphertextCommits, InputVerification, TestEnvironment};
 use futures_util::StreamExt;
@@ -14,9 +14,7 @@ use sqlx::{Postgres, QueryBuilder};
 use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
-use transaction_sender::{
-    ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider, TransactionSender,
-};
+use transaction_sender::{ConfigSettings, NonceManagedProvider, TransactionSender};
 mod common;
 
 sol! {
@@ -35,16 +33,9 @@ sol! {
 #[serial(db)]
 async fn verify_proof_response_success(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -153,16 +144,9 @@ async fn verify_proof_response_empty_handles_success(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -274,16 +258,9 @@ async fn verify_proof_response_concurrent_success(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -393,16 +370,9 @@ async fn verify_proof_response_concurrent_success(
 #[serial(db)]
 async fn reject_proof_response_success(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -505,16 +475,9 @@ async fn verify_proof_response_reversal_already_verified(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = true;
@@ -609,16 +572,9 @@ async fn verify_proof_response_reversal_not_requested(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -713,16 +669,9 @@ async fn reject_proof_response_reversal_not_requested(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -816,16 +765,9 @@ async fn reject_proof_response_reversal_already_rejected(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -919,16 +861,9 @@ async fn verify_proof_response_other_reversal(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1020,16 +955,9 @@ async fn reject_proof_response_other_reversal(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1117,16 +1045,9 @@ async fn verify_proof_response_other_reversal_gas_estimation(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1217,16 +1138,9 @@ async fn reject_proof_response_other_reversal_gas_estimation(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
     let env = TestEnvironment::new(signer_type).await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1319,16 +1233,9 @@ async fn verify_proof_max_retries_remove_entry(
     let mut env = TestEnvironment::new(signer_type).await?;
     env.conf.verify_proof_remove_after_max_retries = true;
     env.conf.verify_proof_resp_max_retries = 2;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1411,16 +1318,9 @@ async fn verify_proof_max_retries_do_not_remove_entry(
     let mut env = TestEnvironment::new(signer_type).await?;
     env.conf.verify_proof_remove_after_max_retries = false;
     env.conf.verify_proof_resp_max_retries = 2;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1522,16 +1422,9 @@ async fn stop_retrying_verify_proof_on_gw_config_error(
     let env =
         TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
             .await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-        .await?;
+    let provider_deploy = env.http_provider()?;
     let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
-            .await?,
+        env.http_sender_inner()?,
         Some(env.wallet.default_signer().address()),
     );
     let already_verified_revert = false;
@@ -1636,5 +1529,215 @@ async fn stop_retrying_verify_proof_on_gw_config_error(
     env.cancel_token.cancel();
     run_handle.await??;
 
+    Ok(())
+}
+
+/// What a Gateway outage costs a proof over HTTP.
+///
+/// `verify_proof` has no unlimited-retry path: every send failure increments
+/// `retry_count`, and the selection query drops rows at
+/// `verify_proof_resp_max_retries`. Over WebSocket that budget was protected by
+/// `BackendGone`, which stopped the sender outright on a dead endpoint. Over
+/// HTTP no such signal exists, so the operation loop keeps cycling against the
+/// dead Gateway and spends the budget — with
+/// `verify_proof_remove_after_max_retries` the proof is then deleted.
+///
+/// This test measures how long that takes with the shipped backoff.
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[tokio::test]
+#[serial(db)]
+async fn gateway_outage_burns_verify_proof_retries(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        verify_proof_resp_max_retries: 6,
+        verify_proof_remove_after_max_retries: true,
+        error_sleep_initial_secs: 1,
+        error_sleep_max_secs: 4,
+        graceful_shutdown_timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+    let mut env = TestEnvironment::new_with_config(signer_type, conf.clone(), false).await?;
+    let provider_deploy = env.http_provider()?;
+    let provider = NonceManagedProvider::new(
+        env.http_sender_inner()?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let input_verification =
+        InputVerification::deploy(&provider_deploy, false, false, false, false).await?;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider_deploy, false).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input_verification.address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Take the Gateway away, then hand the sender a proof it cannot send.
+    env.drop_anvil();
+
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    let started = tokio::time::Instant::now();
+    let mut last_retry_count = 0i32;
+    let mut gone_after = None;
+    while started.elapsed() < Duration::from_secs(120) {
+        let rows = sqlx::query!(
+            "SELECT retry_count, last_error
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        match rows.first() {
+            Some(r) => last_retry_count = r.retry_count,
+            None => {
+                gone_after = Some(started.elapsed());
+                break;
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    println!(
+        "verify_proof under a dead Gateway over HTTP: last observed retry_count={last_retry_count}, \
+row removed after {:?}",
+        gone_after
+    );
+    assert!(
+        gone_after.is_some(),
+        "the proof survived 120 s of outage with retry_count={last_retry_count}; \
+if this now holds, the retry budget is no longer being spent on transport failures"
+    );
+    assert!(
+        !run_handle.is_finished(),
+        "the sender kept running while it discarded the proof"
+    );
+
+    env.cancel_token.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), run_handle).await;
+    Ok(())
+}
+
+/// The same outage over WebSocket, for comparison, on this same code.
+///
+/// `BackendGone` reaches `TransactionSender::run`, which cancels every
+/// operation and returns the error. The proof keeps its remaining budget and
+/// survives for the restart. This is the protection the HTTP move removes.
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[tokio::test]
+#[serial(db)]
+async fn gateway_outage_over_websocket_stops_the_sender_instead(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    use alloy::providers::WsConnect;
+
+    let conf = ConfigSettings {
+        verify_proof_resp_max_retries: 6,
+        verify_proof_remove_after_max_retries: true,
+        error_sleep_initial_secs: 1,
+        error_sleep_max_secs: 4,
+        graceful_shutdown_timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+    let mut env = TestEnvironment::new_with_config(signer_type, conf.clone(), false).await?;
+    let provider_deploy = env.http_provider()?;
+    let ws = alloy::providers::ProviderBuilder::default()
+        .filler(transaction_sender::FillersWithoutNonceManagement::default())
+        .wallet(env.wallet.clone())
+        .connect_ws(
+            WsConnect::new(env.ws_endpoint_url())
+                .with_max_retries(1)
+                .with_retry_interval(Duration::from_millis(200)),
+        )
+        .await?;
+    let provider = NonceManagedProvider::new(ws, Some(env.wallet.default_signer().address()));
+    let input_verification =
+        InputVerification::deploy(&provider_deploy, false, false, false, false).await?;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider_deploy, false).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input_verification.address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+    env.drop_anvil();
+
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // The sender should give up on the endpoint rather than on the proof.
+    let stopped = tokio::time::timeout(Duration::from_secs(60), run_handle).await;
+    let outcome = stopped.expect("the sender must stop on BackendGone over WebSocket")?;
+    let err = outcome.expect_err("stopping is reported as an error");
+    assert!(
+        transaction_sender::is_backend_gone(&err),
+        "expected BackendGone, got: {err}"
+    );
+
+    let rows = sqlx::query!(
+        "SELECT retry_count, last_error
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+        proof_id as i64,
+    )
+    .fetch_all(&env.db_pool)
+    .await?;
+    let retry_count = rows.first().map(|r| r.retry_count);
+    println!(
+        "verify_proof under a dead Gateway over WSS: row present={}, retry_count={:?}",
+        !rows.is_empty(),
+        retry_count
+    );
+    assert!(
+        !rows.is_empty(),
+        "the proof must survive the outage for the restart to retry it"
+    );
     Ok(())
 }

--- a/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_transport_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_transport_tests.rs
@@ -1,0 +1,170 @@
+//! Focused preservation/recovery regressions. The broader campaign is described
+//! in docs/transaction-sender-http-proof-retry-test-protocol.md.
+mod common;
+mod support;
+
+use alloy::primitives::U256;
+use alloy::providers::ProviderBuilder;
+use common::{CiphertextCommits, InputVerification, SignerType, TestEnvironment};
+use rstest::rstest;
+use serial_test::serial;
+use std::time::Duration;
+use support::{Fault, FaultProxy};
+use transaction_sender::{
+    gateway_http_client, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
+    TransactionSender,
+};
+
+#[rstest]
+#[case::estimate_503("eth_estimateGas", Fault::HttpError(503), true, true)]
+#[case::nonce_429("eth_getTransactionCount", Fault::HttpError(429), false, true)]
+#[case::send_deadline("eth_sendRawTransactionSync", Fault::RpcError {
+    code: -32000, message: "context deadline exceeded".into()
+}, true, false)]
+#[case::send_timeout(
+    "eth_sendRawTransactionSync",
+    Fault::DiscardAfter(Duration::from_secs(2)),
+    true,
+    true
+)]
+#[tokio::test]
+#[serial(db)]
+async fn transient_failure_preserves_near_exhausted_proof_and_recovers(
+    #[case] method: &str,
+    #[case] fault: Fault,
+    #[case] remove: bool,
+    #[case] verified: bool,
+) -> anyhow::Result<()> {
+    let conf = ConfigSettings {
+        verify_proof_resp_max_retries: 3,
+        verify_proof_remove_after_max_retries: remove,
+        error_sleep_initial_secs: 1,
+        error_sleep_max_secs: 4,
+        send_txn_sync_timeout_secs: 1,
+        graceful_shutdown_timeout: Duration::from_secs(5),
+        ..Default::default()
+    };
+    let env = TestEnvironment::new_with_config(SignerType::PrivateKey, conf, false).await?;
+    let deploy = env.http_provider()?;
+    let input = InputVerification::deploy(&deploy, false, false, false, false).await?;
+    let ciphertext = CiphertextCommits::deploy(&deploy, false).await?;
+    let proxy = FaultProxy::start(env.http_endpoint_url()).await?;
+    let url = proxy.url();
+    let inner = ProviderBuilder::default()
+        .filler(FillersWithoutNonceManagement::default())
+        .wallet(env.wallet.clone())
+        .connect_reqwest(gateway_http_client(&url)?, url);
+    let provider = NonceManagedProvider::new(inner, Some(env.wallet.default_signer().address()));
+    let sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input.address(),
+        *ciphertext.address(),
+        env.signer.clone(),
+        provider,
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id = i64::from(rand::random::<u32>());
+    sqlx::query(
+        "INSERT INTO verify_proofs
+         (zk_proof_id, chain_id, contract_address, user_address, handles, verified, retry_count)
+         VALUES ($1, 42, $2, $3, $4, $5, 2)",
+    )
+    .bind(proof_id)
+    .bind(env.contract_address.to_string())
+    .bind(env.user_address.to_string())
+    .bind(vec![1u8; 64])
+    .bind(verified)
+    .execute(&env.db_pool)
+    .await?;
+
+    proxy.set_fault(method, fault, None);
+    let initial_calls = proxy.calls(method);
+    let started = tokio::time::Instant::now();
+    let run = tokio::spawn(async move { sender.run().await });
+    let deadline = started + Duration::from_secs(30);
+    loop {
+        let retries: Option<i32> =
+            sqlx::query_scalar("SELECT retry_count FROM verify_proofs WHERE zk_proof_id = $1")
+                .bind(proof_id)
+                .fetch_optional(&env.db_pool)
+                .await?;
+        assert_eq!(
+            retries,
+            Some(2),
+            "transient error must not exhaust or delete proof"
+        );
+        assert!(!run.is_finished());
+        if proxy.calls(method) - initial_calls >= 4 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "fault was not exercised repeatedly"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    // Four attempts require 1 + 2 + 4 seconds of backoff, even for
+    // immediate failures. A success/continue busy loop must fail this check.
+    assert!(started.elapsed() >= Duration::from_secs(7));
+    // Wait for the fourth local timeout too, then observe the row again.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(
+        proxy.calls(method) - initial_calls,
+        4,
+        "retry rate exceeded backoff"
+    );
+    let retries: Option<i32> =
+        sqlx::query_scalar("SELECT retry_count FROM verify_proofs WHERE zk_proof_id = $1")
+            .bind(proof_id)
+            .fetch_optional(&env.db_pool)
+            .await?;
+    assert_eq!(retries, Some(2));
+
+    proxy.clear_all_faults();
+    tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            let present: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM verify_proofs WHERE zk_proof_id = $1)",
+            )
+            .bind(proof_id)
+            .fetch_one(&env.db_pool)
+            .await?;
+            if !present {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        anyhow::Ok(())
+    })
+    .await??;
+
+    // Deletion alone is not success: require the matching on-chain event.
+    if verified {
+        let events = input
+            .VerifyProofResponse_filter()
+            .from_block(0)
+            .query()
+            .await?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0.zkProofId, U256::from(proof_id as u64));
+        assert_eq!(
+            events[0].0.ctHandles,
+            vec![alloy::primitives::FixedBytes([1u8; 32]); 2]
+        );
+    } else {
+        let events = input
+            .RejectProofResponse_filter()
+            .from_block(0)
+            .query()
+            .await?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0.zkProofId, U256::from(proof_id as u64));
+    }
+    env.cancel_token.cancel();
+    tokio::time::timeout(Duration::from_secs(10), run).await???;
+    Ok(())
+}

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -1,0 +1,443 @@
+# HTTP transaction sender: proof retry reliability test protocol
+
+Recorded: 2026-09-11. Reviewed baseline: `8833a4f06` on v0.13.4.
+
+Status: candidate patch implemented; focused local checks
+are recorded below. The broader test campaign and release gate remain pending.
+Use `67762d493` as the unfixed transport baseline, not the candidate patch.
+The historical evaluation used `8833a4f06`.
+
+## Candidate implementation and campaign handoff
+
+The selected remedy preserves proof eligibility and lets the existing operation
+loop back off. It does not stop/restart the process for HTTP failures, introduce
+request expiry, or depend on fresh client requests for sender-level recovery.
+
+After the existing contract/configuration-error checks, `process_proof` uses
+`is_transient_gateway_error` in `src/ops/common.rs`. A matching failure increments
+the existing failure metric, logs a preservation warning, and returns `Err`
+without updating the proof row. Consequently the terminal `retry_count` and its
+associated database `last_error`/`last_retry_at` fields remain unchanged. Use logs,
+RPC observations, and the failure counter to observe transient attempts; do not
+interpret an unchanged database retry timestamp as an idle sender.
+
+The classifier's explicit policy is:
+
+| Error | Preserve terminal retry budget? |
+| --- | --- |
+| HTTP 408, 429, 500, 502, 503, 504 | Yes |
+| Typed reqwest connection, timeout, request-send, or body-read error, including through an error source chain | Yes |
+| Exact existing local `eth_sendRawTransactionSync timeout` custom error | Yes |
+| `BackendGone` or missing batch response | Yes; BackendGone still reaches the existing shutdown gate |
+| JSON-RPC code 429 | Yes |
+| JSON-RPC code -32000 or -32603 with exact message `context deadline exceeded`, `service unavailable`, `temporarily unavailable`, or `too many requests` (case/outer whitespace normalized) | Yes |
+| Other errors | Existing handling |
+
+No generic substring match for “timeout” or “unavailable” is used. Contract
+reverts and recognized permanent coprocessor configuration errors are handled
+before this classifier. Unknown errors, authentication errors, nonce errors,
+and unsuccessful receipts retain existing behavior. This is an intentional
+allowlist: compare actual Gateway error codes/messages with it during the
+campaign, and report uncovered infrastructure classes rather than claiming
+universal outage protection.
+
+### Review decisions: HTTP 500 and provider-specific rate limits
+
+HTTP 500 is intentionally classified as transient. The status alone does not
+establish that the proof or sender configuration is permanently invalid, so
+preserving unfinished work takes precedence over exhausting its retry budget.
+This differs from excluding 500 because it might represent an application
+failure. The tradeoff is explicit: a persistent application defect returning
+500 can keep the affected work retrying indefinitely and may impede queue
+progress. Operation backoff bounds attempts; it does not guarantee fairness or
+completion. Monitor repeated failures and queue age, and retain selective-error
+fairness testing as a release-gate requirement. An HTTP 500 response is distinct
+from an HTTP 200 response carrying an unknown JSON-RPC internal error; the
+latter still follows limited-retry accounting.
+
+The JSON-RPC allowlist is deliberately narrower than Alloy's general
+provider-specific rate-limit policy. For example, JSON-RPC `-32005` is not
+covered even though Alloy recognizes it as a rate-limit signal. Such errors
+retain limited-retry accounting and can exhaust proof eligibility if repeated.
+Do not infer support from the English meaning of an error message. Capture the
+actual Gateway error codes and compare them with this policy; extend it with
+explicit classification and preservation/recovery tests if the target Gateway
+uses another infrastructure error class.
+
+For comparison, the HTTP migration on
+`rudy/feat/http-for-gw-listener-and-tx-sender`, reviewed at `6eb0c5cf1`
+(migration commit `f3788d7b5`, Alloy 2.2.0), uses transport retries and exits the
+sender when those retries exhaust. It excludes HTTP 500 and inherits Alloy's
+broader rate-limit recognition. This patch keeps retry ownership in the
+operation loop, retains the existing send deadline, and explicitly covers
+reqwest connection/timeouts and the allowlisted Conduit deadline responses.
+Both approaches aim to preserve work for classified infrastructure failures;
+they do not have identical failure coverage. Neither resolves the deferred
+accepted-but-unmined nonce reconciliation problem.
+
+No database schema, dependency, CLI default, add-ciphertext retry accounting,
+nonce allocation/reset logic, or submission RPC changes are included. Batch
+sibling cancellation and accepted-but-unmined nonce recovery remain follow-up
+work. Restarts do not revive rows already exhausted before this patch; account
+for pre-existing exhausted work explicitly when preparing the campaign.
+
+### Deployment configuration
+
+The local stack now passes `GATEWAY_URL` (the existing HTTP variable) to the
+sender and explicitly sets both batch limits to 10. The listener continues to
+use `GATEWAY_WS_URL`. The Rust CLI defaults remain unchanged.
+
+Helm gains optional `txSender.config.gatewayUrl`, accepting `value` or
+`valueFrom`, so the listener's `commonConfig.gatewayUrl` can remain WebSocket.
+If omitted, the sender still falls back to the shared URL for chart
+compatibility; HTTP sender builds reject a WebSocket fallback at startup.
+Example candidate values (use the actual endpoint or a secret reference):
+
+```yaml
+txSender:
+  config:
+    gatewayUrl:
+      value: https://gateway.example/rpc
+  extraArgs:
+    - --verify-proof-resp-batch-limit=10
+    - --add-ciphertexts-batch-limit=10
+```
+
+Merge these flags with the deployment's existing `extraArgs`; do not replace
+unrelated flags or add duplicate batch flags. Batch 10 + 10 is a conservative
+candidate configuration, not a production capacity claim. Repeat campaign runs
+with actual deployment settings, including 128 proof concurrency if that is
+still being considered. Preserve the deployed retry limit of 15 in those runs.
+
+### Focused checks and remaining validation
+
+- Four classifier unit tests cover the HTTP allowlist and exclusions, RPC
+  message/code boundaries, local timeout classification, actual refused HTTP
+  connections, actual request deadlines, and invalid-URL exclusion.
+- `gateway_outage_preserves_verify_proof_retries` replaces the historical
+  deletion assertion. It requires more observed failures than the terminal
+  budget allows while the proof remains eligible.
+- Four `verify_proof_transport_tests` cases start at retry count 2 with maximum
+  3, exercise repeated faults, check backoff, clear the fault, and require both
+  database completion and a matching contract event. They cover estimation
+  HTTP 503, nonce-read HTTP 429, submission RPC deadline errors, and local send
+  timeouts. Across the cases they exercise removal enabled/disabled and
+  verification/rejection responses. This is sampled coverage, not the full
+  cross-product in section A.
+- Proxy additions return HTTP/RPC errors before forwarding and provide
+  `DiscardAfter`, which never forwards an expired request after fault removal.
+- Local Helm rendering checks cover shared-URL fallback, the sender-only HTTP
+  override, secret references, and the unchanged listener URL. Compose parsing
+  checks the explicit HTTP URL and batch arguments.
+
+Local execution results on 2026-09-11 (original retry patch `0ffb9a3ba`,
+before semantic history rewriting):
+
+| Check | Result |
+| --- | --- |
+| Classifier unit tests | 4/4 passed |
+| HTTP transport policy tests | 5/5 passed |
+| New fault/recovery integration cases | 4/4 passed, 67.73 seconds |
+| Existing proof regressions, including AWS signing, permanent configuration errors, and retry exhaustion | 32/32 passed |
+| Updated connection-refusal preservation test | 1/1 passed on corrected rerun, 15.10 seconds |
+| Helm renders and Compose configuration | Passed |
+| Rust formatting, diff whitespace, and protocol links | Passed |
+
+The first proof-suite run passed all 32 other cases. The updated outage test
+passed its preservation assertions but failed cleanup because its inherited
+two-second graceful-shutdown allowance was shorter than the existing four-second
+backoff. The test allowance was raised to five seconds and the targeted rerun
+passed. Runtime shutdown behavior was not changed. These results account for
+46 distinct passing tests across the selected suites, not a rerun of every
+transaction-sender test.
+
+No real Gateway, client-retry, long-outage, or mixed-load campaign has been run
+for this candidate.
+
+Commands from `coprocessor/fhevm-engine` (integration tests require the existing
+Anvil/PostgreSQL harness; the full proof suite also exercises AWS signing):
+
+```sh
+cargo test --release --locked -p transaction-sender --lib transient_gateway_tests
+cargo test --release --locked -p transaction-sender --test verify_proof_transport_tests
+cargo test --release --locked -p transaction-sender --test verify_proof_tests
+cargo test --release --locked -p transaction-sender --test https_transport_tests
+```
+
+The campaign still needs the baseline negative control with the new acceptance
+assertions, production-duration outages, full fault matrix, database transition
+auditing, partial failures/fairness, repeated restart and mixed-operation cases,
+and actual client/relayer expiry and retry behavior. Unit classification of a
+fault is not equivalent to end-to-end validation of that fault.
+
+## Scope and acceptance contracts
+
+On the unfixed baseline, issue 1 is proof retry-budget exhaustion during Gateway infrastructure failures.
+HTTP connection errors do not produce the WebSocket `BackendGone` signal. The
+sender can keep retrying while consuming the proof's terminal retry budget.
+With removal enabled, exhausted rows are deleted; with removal disabled, they
+remain in the database but are excluded from processing.
+
+The original protocol evaluates a sender-level preservation fix:
+
+> A Gateway infrastructure failure must not make unfinished proof work disappear
+> or become permanently ineligible. After connectivity returns, the sender must
+> complete that work automatically.
+
+The user clarified that clients time out waiting for verification responses and
+are expected to retry. This introduces a second possible acceptance contract:
+
+> An expired individual request may be abandoned, provided a compliant client
+> can obtain a correct result through supported retries after recovery, within
+> an agreed latency and retry budget, without manual intervention.
+
+These are different guarantees. Client retries can mitigate issue 1 without
+fixing sender-level preservation. Report which contract was tested. The original
+preservation protocol below remains appropriate for assessing a preservation
+fix; the additional end-to-end protocol assesses reliance on client retries.
+
+Neither protocol establishes issue-2 nonce safety for accepted-but-unmined
+submissions. Record any such failures separately rather than overlooking them.
+
+## Repository evidence
+
+- [Proof retry and selection logic](../coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs):
+  unclassified send failures increment `retry_count`; selection requires
+  `retry_count < verify_proof_resp_max_retries`.
+- [Existing outage regression file](../coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs):
+  at baseline `8833a4f06`, `gateway_outage_burns_verify_proof_retries` demonstrates deletion with six
+  retries and 1–4 second backoff. Its reported approximately 19-second result
+  must not be described as a measurement with the deployment's fifteen retries.
+  The candidate replaces it with a preservation assertion, as described above.
+- [Fault proxy](../coprocessor/fhevm-engine/transaction-sender/tests/support/mod.rs)
+  and [failure tests](../coprocessor/fhevm-engine/transaction-sender/tests/https_failure_mode_tests.rs)
+  provide a starting harness.
+- [Relayer deduplication](../relayer/src/store/sql/repositories/input_proof_repo.rs):
+  identical input requests conflict while the existing request is neither
+  `failure` nor `timed_out`; completed requests can return cached results.
+- [Relayer v2 handler](../relayer/src/http/endpoints/v2/handlers/input_proof.rs)
+  dispatches fresh work only for newly inserted requests.
+- [Relayer timeout processing](../relayer/src/store/sql/repositories/timeout_repo.rs)
+  marks old `receipt_received` input requests `timed_out` using the configured
+  timeout. This is a server-side state transition, distinct from a client
+  stopping its wait. Verify other state timeout paths in the deployed flow.
+- [Gateway request contract](../gateway-contracts/contracts/InputVerification.sol)
+  assigns a fresh `zkProofId` to each successful `verifyProofRequest` call.
+- [Gateway listener](../coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs)
+  inserts proof work with `ON CONFLICT(zk_proof_id) DO NOTHING`. Replaying an
+  event for an existing exhausted row does not reset its retries.
+
+These are observations of this branch, not proof that every deployed client or
+API version follows this exact path. Record the actual client/API versions and
+runtime timeout configuration before running end-to-end tests.
+
+## A. Sender-level preservation protocol
+
+### A1. Harness and observations
+
+Use the real transaction sender, PostgreSQL, and a method-aware fault proxy in
+front of Anvil with a verification contract. Keep Anvil alive while injecting
+network outages so chain state survives restoration. Use a fixture that permits
+checking actual verification/rejection effects, not merely unconditional mock
+receipts. If consensus requires multiple coprocessors, distinguish this sender's
+contribution from completion of the overall request.
+
+For each proof, record original identity/payload, initial retry count, every
+terminal retry-counter change, deletion, RPC outcome, contract completion, and
+sender exit/restart. Use a test-only database audit mechanism so polling cannot
+miss intermediate updates or deletion/recreation. Database disappearance is not
+evidence of success; correlate it with contract completion or an explicitly
+expected permanent outcome.
+
+Define each injected error's classification before running the test. Do not
+classify every JSON-RPC error as an infrastructure failure.
+
+### A2. Negative control
+
+Run the unfixed baseline with max retries 3, removal enabled, the existing
+1–4 second backoff, and a valid unfinished proof. After startup, refuse Gateway
+connections. Require the acceptance assertions to detect exhaustion/deletion.
+Repeat with removal disabled and require detection of permanent ineligibility.
+
+Run the same acceptance assertions against the candidate. Confirm that work was
+selected and the fault was encountered; an idle sender must not pass.
+
+### A3. Fault matrix
+
+Apply faults separately to gas estimation, nonce retrieval when its cache is
+empty, and submission. Include other prerequisite RPCs actually used by the
+deployed signing/provider configuration. A submission-only classifier is not
+sufficient when gas estimation can fail first.
+
+| Scenario | Injection | Required result |
+| --- | --- | --- |
+| Gateway unavailable | Refuse connections after startup | Preserve eligibility; recover after restoration |
+| Connection lost | Reset/close before forwarding | Same |
+| Gateway stops answering | Hold without forwarding; discard held requests | Bounded request duration and retries; preserved work |
+| HTTP overload/unavailability | 429, 502, 503, 504 separately | No terminal retry-budget consumption |
+| Transient RPC failure | HTTP 200 carrying an explicitly classified transient JSON-RPC error | Same |
+| Submission-only failure | Healthy reads/health probes; transient send errors | Health probes must not mask proof loss |
+| Intermittent failure | Deterministic fail/fail/succeed and ten-failures/recover sequences | No exhaustion; automatic completion |
+
+For core issue-1 isolation, failed submissions must not reach Anvil. The existing
+proxy's `Blackhole` fault forwards parked requests when cleared; add a mode that
+discards them instead. Its current 180-second park cap must also be accounted
+for in longer tests. Otherwise recovery unintentionally introduces ambiguous
+acceptance or changes the injected error class.
+
+Use deterministic fault schedules and barriers. A timeout or reset after
+upstream acceptance belongs in the additional issue-2 interaction tests.
+
+### A4. Survival and recovery sequence
+
+1. Seed valid proofs with retry counts 0 and `max_retries - 1`.
+2. Confirm that the sender encounters the injected failure.
+3. Keep the failure active beyond several times the measured unfixed exhaustion
+   window for that configuration.
+4. Require every unfinished proof to remain present and eligible, with no
+   infrastructure-induced increase in its terminal retry count.
+5. Restore connectivity without database repair or new client requests.
+6. Require every proof to complete before a predeclared recovery deadline.
+
+The near-exhaustion case detects implementations that spend one retry before
+shutting down and then delete the proof on restart.
+
+For retry-in-place, require repeated fault encounters. For shutdown/restart,
+use a supervisor harness and require repeated restart cycles with no cumulative
+terminal retry-budget consumption. Test startup while the Gateway is down too.
+
+Use max retries 3 for fast regression tests, then repeat with max retries 15 and
+the actual deployment backoff, request deadlines, and batch settings. Start with
+a five-minute outage, extending it if needed to exceed several unfixed
+exhaustion windows. Test both settings of removal-after-exhaustion.
+
+Set recovery deadlines before examining candidate results. Base them on the
+healthy drain time for the same workload plus configured polling/backoff/startup
+delays and explicit scheduling allowance; report the numerical bounds used.
+
+### A5. Queue progress, restarts, and bounded load
+
+Repeat with more than two batches of proofs, both verification and rejection
+responses, new proofs arriving during/after outages, and concurrent
+add-ciphertext work. Include repeated outage/recovery cycles and sender restarts
+with the same database and chain.
+
+Require later work to progress: preserving the oldest batch forever while
+starving subsequent work is not recovery. Include selective failures confined
+to early items and verify the candidate's declared fairness policy.
+
+Measure attempt timestamps, active tasks, and outstanding requests. With the
+current policy and immediate errors, operation-level backoff should be roughly
+1, 2, 4, 4... seconds, allowing scheduling tolerance. Declare equivalent bounds
+if the candidate changes this policy. Requests within a batch can be concurrent;
+do not confuse their spacing with operation-level backoff.
+
+A candidate that skips the retry increment but returns “success, more work” can
+create a tight loop. Require bounded concurrency, no task/request accumulation
+over repeated cycles, and bounded supervisor restart frequency.
+
+### A6. Permanent-error controls
+
+Require valid work to complete and already-verified/already-rejected responses
+to retain their intended cleanup behavior. Explicitly permanent configuration
+errors must still become terminal. Errors designated for limited retries must
+retain that behavior.
+
+Test permanent failure -> infrastructure outage -> permanent failure. The
+outage must neither consume nor erase the pre-existing terminal retry history.
+
+### A7. Sender-level release gate
+
+- Baseline fails the acceptance assertions; candidate passes.
+- Infrastructure failures preserve unfinished work and eligibility.
+- Recovery needs no manual repair or fresh client request.
+- Retry, concurrency, and restart behavior remain bounded.
+- Permanent-error semantics are unchanged or explicitly reviewed.
+- Production-configuration and mixed-operation restart cases pass.
+
+Passing establishes issue-1 preservation within the tested failure model. It
+does not prove arbitrary-outage reliability or accepted-but-unmined nonce safety.
+
+## B. End-to-end client-retry protocol
+
+### B1. Why client retries change the assessment
+
+If the intended contract permits abandoning expired requests, losing an
+individual sender job need not permanently prevent the user from verifying the
+input. The impact can instead be an additional timeout/retry cycle, duplicated
+work/fees, and lower availability during recovery. Sender-level persistence is
+then a design choice to evaluate against that end-to-end contract, not an
+unconditional requirement inferred solely from the presence of a queue.
+
+However, a client timeout alone does not imply a fresh Gateway request. In this
+branch's relayer v2 path, retries while the old request remains active are
+deduplicated. Once it becomes `failure` or `timed_out`, an identical request can
+be inserted anew and dispatched. A fresh successful Gateway request receives a
+new proof ID. Test that entire transition and the actual client retry policy.
+
+An outage shorter than the client's timeout can still delete work early and
+force the user to wait for relayer expiry despite the Gateway having recovered.
+Client-side waiting expiry must not be assumed to cancel or expire the on-chain
+request; late responses may still arrive.
+
+### B2. Full-stack harness and identifiers
+
+Use the supported client/API, relayer, Gateway listener, proof worker, sender,
+database, and Gateway contracts with the required consensus topology. Inject
+sender-path failures after the initial request reaches the Gateway. Also test
+a broader outage affecting request submission and relayer observation.
+
+Track one logical verification across client attempts, relayer external job IDs,
+content-derived internal IDs, Gateway proof IDs, coprocessor rows, and final
+client-visible results. Record client wait/retry limits, relayer state-expiry
+timeouts and scheduler cadence, retry delays, and sender settings independently.
+Use the same logical input for retries; generating different input would bypass
+the deduplication behavior being tested.
+
+### B3. Required scenarios
+
+| Scenario | Evidence required |
+| --- | --- |
+| Sender job deleted; client retries while relayer job remains active | Observe deduplication; verify the client continues through eventual expiry rather than exhausting its own retry budget |
+| Retry after relayer marks request timed out/failed | Observe fresh dispatch, new Gateway proof ID, eligible coprocessor work, and a correct client-visible result |
+| Gateway recovers before client/relayer timeout | Measure additional avoidable waiting after recovery against the agreed latency bound |
+| Outage spans multiple client and relayer timeout windows | Completion after recovery within supported retry policy; explicit bounded failure if the policy is exhausted |
+| Old proof completes after a replacement request starts | Correct correlation; no incorrect acceptance/rejection or corruption of the replacement request |
+| Old proof completes just before/after relayer expiry | Deterministic race tests for cached-result versus fresh-request behavior |
+| Many clients retry together | Bounded request amplification and recovery drain time; no repeated exhaustion under renewed load |
+| Relayer/sender restarts around expiry and resubmission | Persistent state/deduplication permits recovery without manual repair |
+
+Exercise sender exhaustion with removal both enabled and disabled. A new proof
+ID should not be obstructed by an old exhausted row; replaying the same ID must
+not be mistaken for fresh eligible work. Verify this rather than assuming it.
+
+Use controlled clocks/barriers for race tests where practical, then perform a
+run with actual deployment timeout values. Include failures/rejections as well
+as successful verification. Explicitly test the supported application's retry
+behavior; an idealized client retrying forever cannot validate a finite policy.
+
+### B4. End-to-end acceptance and reporting
+
+Predeclare the supported outage duration, maximum client-visible recovery
+latency, client retry budget, and acceptable request/fee amplification. There is
+no finite retry policy that guarantees completion across an arbitrarily long
+outage. Report bounded failure behavior outside the supported window.
+
+Within that window require a correct result for each logical input, no permanent
+deduplication trap, no manual repair, correct handling of late results, and load
+that remains within declared limits. Record unnecessary proof computation and
+Gateway calls as well as final success. Do not use `latest = pending` alone as
+evidence that all logical requests completed.
+
+Passing B without A supports deploying with an explicitly accepted client-retry
+recovery contract; it must not be reported as a sender preservation fix. Passing
+A and B supports both guarantees. Issue 2 requires its own nonce reconciliation
+tests and remains outside either approval claim.
+
+## Result record
+
+For every run retain commit hashes, client/API versions, topology and config,
+fault class/location/schedule, expected classification, proof/job identities,
+database transition audit, RPC counts/outcomes, contract evidence, restart
+history, recovery time, and pass/fail reason. Record baseline and candidate
+results separately and identify any deviations from the predeclared bounds.

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -579,3 +579,28 @@ fault class/location/schedule, expected classification, proof/job identities,
 database transition audit, RPC counts/outcomes, contract evidence, restart
 history, recovery time, and pass/fail reason. Record baseline and candidate
 results separately and identify any deviations from the predeclared bounds.
+
+## Fair scheduling follow-up
+
+Transient failures now update only `last_retry_at`; they still preserve the
+finite retry count, stored error and proof payload. Earlier zero-mutation audit
+results describe the pre-scheduling patch. Current audits must allow scheduling
+timestamp updates and reject all other mutations or deletion during transient
+failure. No schema migration is required.
+
+Selection excludes attempts newer than `error_sleep_max_secs` (minimum one
+second) and orders eligible rows by `COALESCE(last_retry_at, created_at)`, then
+proof ID. This bounded per-row delay also applies to existing limited-failure
+timestamps. Operation-level backoff remains. New arrivals must not indefinitely
+postpone a due retry, and failing rows must not monopolize the first batch.
+The timestamp persists across restart; there is no process-local retry cursor.
+
+Mixed batches drain every task before returning an error, retaining any fatal
+BackendGone signal. Otherwise the first failed task could cancel healthy
+submissions after nonce allocation. This avoids that cancellation path without
+changing nonce reconciliation or accepted-but-unmined retry handling.
+
+The mixed campaign streams new proofs at 200 ms intervals, checks complete
+healthy-proof drainage during each fault/restart cycle, observes repeated
+deferred attempts, audits protected fields, and requires contract evidence for
+all 50 proofs after recovery. Run the normal proof regression suite as well.

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -170,6 +170,76 @@ auditing, partial failures/fairness, repeated restart and mixed-operation cases,
 and actual client/relayer expiry and retry behavior. Unit classification of a
 fault is not equivalent to end-to-end validation of that fault.
 
+## Review follow-up: startup errors and credential-safe diagnostics
+
+The reviewer follow-up keeps the public `get_chain_id` API fallible: an invalid
+URL scheme returns an error rather than panicking or retrying forever. All
+callers propagate the result. The former `client_policy_is_bounded` assertion
+was removed because comparing two duration literals did not exercise the client.
+URL rejection tests now include credential markers and the public startup probe.
+The binary parses its Gateway URL after clap so malformed-URL errors cannot echo
+the supplied credential-bearing argument.
+
+Both legacy provider reconnect flags remain accepted. The review corrects the
+documentation: startup probing uses `graceful_shutdown_timeout` as its interval
+in this branch, as it did before the transport switch; `provider_retry_interval`
+does not control it. This follow-up does not change that startup timing.
+
+`diagnostics::safe_rpc_error` emits fixed error categories, HTTP/RPC codes, and a
+small allowlist of known messages. It never formats arbitrary Gateway response
+bodies, RPC data, custom error strings, or local-signing error details. This
+protects against bare tokens echoed by an upstream as well as full URLs.
+`safe_error` locates typed RPC/reqwest failures inside error chains before
+formatting them; other non-Gateway diagnostics retain their existing text.
+Original error objects still drive retry classification, contract error decoding,
+and BackendGone handling. Sanitization changes presentation, not those decisions.
+
+Safe diagnostics are used for startup probes, operation failures, both proof and
+ciphertext error columns, health responses, and final process-error output.
+The sender's logging setup additionally disables Alloy/HTTP/TLS dependency events
+and spans that independently expose URLs or response bodies, at all log levels.
+The filter is global to both JSON logging and OTLP. Application logs and metrics
+remain available. Shared tracing initialization retains its existing default
+behavior for other services; only the sender opts into this filter. Library
+consumers supplying their own tracing subscriber must apply the same filter if
+they enable dependency diagnostics.
+
+This prevents new sender diagnostic leaks. It does not rewrite previously
+persisted error strings or purge historical logs in external stores. Historical
+cleanup must target the actual deployment stores; URL-only substitution is not
+sufficient if old response bodies contain bare tokens.
+
+Additional focused validation:
+
+- Unit cases cover credential-bearing HTTP errors, custom/local errors, RPC
+  messages/data, malformed JSON, and anyhow contexts, retaining original types.
+- Binary startup tests inspect stdout/stderr for malformed and unsupported
+  credential-bearing URLs.
+- `gateway_diagnostics_tests` uses real providers and PostgreSQL, captures logs
+  with TRACE enabled, and injects URLs containing user/password/path/query
+  markers plus an independent bare token. HTTP 400, HTTP 429, RPC errors, and
+  malformed JSON exercise both limited and unlimited database-write paths. It
+  also checks startup-probe and health diagnostics.
+- Re-run the classifier and proof-preservation/recovery regressions to ensure
+  sanitizing diagnostics does not change recovery behavior.
+
+Local validation on 2026-09-11 passed all 18 targeted tests: 6 library tests,
+7 HTTP/startup tests, 1 database/log privacy integration test, and 4 proof
+preservation/recovery tests. A separate binary smoke check at TRACE with a
+credential-bearing unreachable HTTP endpoint also passed without leaking markers.
+Changed Rust files pass formatting checks; the workspace-wide formatting check
+reports pre-existing differences in generated Gateway bindings.
+
+Deployed JSON-log and OTLP-export inspection with synthetic credential markers
+remains part of the campaign; do not use real credentials as assertion output or
+fault-response fixtures.
+
+```sh
+cargo test --release --locked -p transaction-sender --lib \
+  --test https_transport_tests --test gateway_diagnostics_tests \
+  --test verify_proof_transport_tests
+```
+
 ## Scope and acceptance contracts
 
 On the unfixed baseline, issue 1 is proof retry-budget exhaustion during Gateway infrastructure failures.

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -1,5 +1,7 @@
 # HTTP transaction sender: proof retry reliability test protocol
 
+Deployment prerequisites and observation steps: [HTTP rollout notes](transaction-sender-http-rollout.md).
+
 Recorded: 2026-09-11. Reviewed baseline: `8833a4f06` on v0.13.4.
 
 Status: candidate patch implemented; focused local checks

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -297,6 +297,18 @@ client polling does not justify deleting unfinished proofs.
 
 ### C. Incident-specific decryption acceptance matrix
 
+Focused execution results are recorded in
+[the campaign log](transaction-sender-validation-campaign-2026-09-11.md#sdk-readiness-campaign-continuation).
+The actual SDK request implementation reached terminal readiness 503 at about
+224 seconds against both relayer versions with mocked Gateway readiness.
+Polling-default/floor and shortened final-attempt/fresh-request controls passed.
+The separate real-stack public-decryption case passed on v0.13.4 with SDK
+0.13.2: readiness expiry at 224.131 seconds, followed by correct plaintext
+from one explicit fresh call after sender recovery at 233.200 seconds.
+This does not establish automatic application-wrapper retries, full-stack
+user decryption, or full-stack rollback behavior.
+
+
 Run with the specified SDK version against relayer v0.13.4, then repeat on
 v0.13.0. Record application wrapper version, resolved SDK package integrity,
 relayer image digest and effective runtime retry configuration. Use real

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -269,6 +269,62 @@ fix; the additional end-to-end protocol assesses reliance on client retries.
 Neither protocol establishes issue-2 nonce safety for accepted-but-unmined
 submissions. Record any such failures separately rather than overlooking them.
 
+## Deployed readiness boundary (clarified 2026-09-11)
+
+The deployment owner identifies the application as `@zama-fhe/sdk@3.5.1`
+wrapping `@fhevm/sdk@0.13.2` (commit `07fb05fb7`), with relayer v0.13.4
+and v0.13.0 as rollback. These deployment identities are supplied information;
+the wrapper's application-level retry behavior has not been independently tested.
+The SDK's `RelayerAsyncRequest.ts` is byte-identical between that commit and
+this branch. Its GET 503 path throws immediately; it does not start a fresh
+request. The default one-hour global deadline and 1,440-loop cap therefore do
+not provide recovery after `readiness_check_timed_out`. Network fetch retries
+and polling 202 responses are different from application resubmission after a
+terminal error. Do not infer the latter from the former.
+
+The readiness loop and testnet example settings are identical at relayer tags
+v0.13.0, v0.13.2 and v0.13.4: 75 attempts separated by three-second sleeps.
+There are 74 sleeps before exhaustion, approximately 222 seconds plus RPC time;
+“225 seconds” is an operational approximation, not a hard wall-clock deadline.
+A never-ready contract result produces the readiness timeout; contract RPC
+errors can produce a different terminal error. Record both separately.
+
+This readiness check concerns ciphertext availability for **decryption**.
+It is distinct from input-proof job expiry and redispatch in section B.
+The existing mock input-proof expiry test does not validate the incident's
+readiness boundary. Preserve section A's unconditional sender recovery gate;
+client polling does not justify deleting unfinished proofs.
+
+### C. Incident-specific decryption acceptance matrix
+
+Run with the specified SDK version against relayer v0.13.4, then repeat on
+v0.13.0. Record application wrapper version, resolved SDK package integrity,
+relayer image digest and effective runtime retry configuration. Use real
+ciphertext registration and decryption in the local stack; mocked readiness
+checks are focused controls only. Include both public and user decryption.
+
+| Scenario | Required observation |
+| --- | --- |
+| Ciphertext registration delayed, readiness restored before the final check | Original request completes correctly, with no terminal readiness error or application resubmission. Correlate sender submission, Gateway registration, readiness checks and SDK result. |
+| Ciphertext remains unavailable through all 75 checks | Relayer returns 503 with `readiness_check_timed_out`; actual SDK call rejects on that response, without waiting an hour or automatically issuing another POST. Count GETs and POSTs. |
+| Recovery immediately before versus after the final readiness observation | Before: existing request can succeed. After: terminal request stays failed; test an explicit fresh application call after recovery and establish its deduplication/result behavior. Do not assume input-proof deduplication rules apply to decryption. |
+| SDK receives network errors, 202 and terminal 503 | Verify network retry and Retry-After polling independently; neither may be reported as retrying the terminal 503. Include absent Retry-After and a value below the SDK's one-second floor. |
+| Sender-wide outage and selective proof failures during readiness | Track addCiphertext progress independently of proof responses. Require recovery without DB repair; record later-proof starvation as a separate failing gate even if decryption completes. |
+| Outage exceeds the readiness window | Preserve sender work and recover it; expect the original SDK call to fail. Any claim of automatic user recovery requires observing an application-level retry policy, not an idealized retrying test client. |
+
+Use shortened attempt intervals for deterministic boundary/race tests, and at
+least one unscaled 75-attempt run per relayer version. Synchronize boundary
+injection to observed check numbers, not a sleep near 225 seconds. Retain a
+monotonic timeline, readiness call counts, SDK HTTP counts, job IDs, terminal
+labels and final plaintext correctness. SDK poll counts alone do not measure
+relayer check counts. Keep the extra KMS-share wait and its latency separate
+from the readiness window.
+
+Passing preservation and HTTP performance tests supports the sender patch;
+it does not promise uninterrupted client success across an outage longer than
+the relayer readiness budget. Automatic resubmission after 503 remains an
+application behavior to establish, not a requirement to redesign this patch.
+
 ## Repository evidence
 
 - [Proof retry and selection logic](../coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs):

--- a/docs/transaction-sender-http-proof-retry-test-protocol.md
+++ b/docs/transaction-sender-http-proof-retry-test-protocol.md
@@ -604,3 +604,18 @@ The mixed campaign streams new proofs at 200 ms intervals, checks complete
 healthy-proof drainage during each fault/restart cycle, observes repeated
 deferred attempts, audits protected fields, and requires contract evidence for
 all 50 proofs after recovery. Run the normal proof regression suite as well.
+
+## Unreadable-response follow-up
+
+Treat Alloy `RpcError::DeserError` as transient. HTTP 200 carrying HTML, an
+empty body or malformed JSON provides no evidence of invalid proof work. Keep
+retry count and stored error unchanged, record the scheduling timestamp, and
+retry fairly with backoff. A persistently incompatible RPC response can therefore
+remain pending indefinitely, but must not prevent healthy proof progress.
+
+Run each response shape at estimation, nonce lookup and submission (nine real
+HTTP fault-proxy cases), with removal enabled and retry count at max minus one.
+Require repeated attempts, protected-field audit preservation, bounded attempt
+rate, and matching contract evidence after restoring valid responses. Retain
+the credential-leak test: unreadable bodies must remain absent from diagnostic
+sinks. Explicit transaction/contract errors keep their existing policy.

--- a/docs/transaction-sender-http-rollout.md
+++ b/docs/transaction-sender-http-rollout.md
@@ -1,0 +1,93 @@
+# Transaction sender HTTP rollout — release 0.13.x
+
+This rollout moves only the sender's Gateway transport to HTTP(S), preserves
+proof work on classified infrastructure failures, schedules retries fairly,
+and sanitizes Gateway diagnostics. The Gateway listener remains on WebSocket.
+Chart version: `0.12.2`. No database migration is required.
+
+## Before deployment
+
+- Confirm all required CI checks, including standard e2e, pass for the exact
+  submitted release HEAD. CI is running; confirmation is pending from the
+  release owner. Record the commit, CI run and deployed image digest in the
+  release record. Earlier local e2e/soak results are not final-HEAD evidence.
+- Set **`txSender.config.gatewayUrl` explicitly to the HTTPS endpoint** in the
+  actual deployment values. Keep `commonConfig.gatewayUrl` on the listener's
+  existing WSS endpoint. An omitted sender override falls back to the shared
+  URL; a WSS fallback is rejected at startup and can cause a CrashLoopBackOff.
+- Render the actual values and inspect the sender and listener `GATEWAY_URL`
+  entries separately. For secret references, verify the referenced key exists
+  in the target namespace and contains the correct endpoint scheme, without
+  copying credentials into logs or the release record. Check any independent
+  environment/argument overrides too.
+- Verify the endpoint supports `eth_sendRawTransactionSync` on the intended
+  chain. Retain the reviewed batch/retry/polling settings; do not inherit
+  different defaults accidentally. Local compose uses batches 10 + 10 and
+  twenty-second polling; Helm's one-second polling and CLI batch defaults are
+  different. Local throughput measurements are not a production capacity promise.
+
+Example sender override using an existing deployment-managed secret:
+
+```yaml
+txSender:
+  config:
+    gatewayUrl:
+      valueFrom:
+        secretKeyRef:
+          name: gateway-rpc
+          key: https-url
+```
+
+Replace the example secret name/key with the actual reference. The chart also
+accepts `gatewayUrl.value` for a literal endpoint. Do not configure both forms.
+The shared listener setting is deliberately omitted from this example: retain
+its existing value.
+
+## During rollout
+
+Use the existing deployment procedure. Confirm startup succeeds against the
+intended chain and that both proof responses and ciphertext submissions make
+progress. Observe oldest pending proof age, pending queue size, completion rate,
+submission errors, process memory and restarts against the pre-rollout baseline.
+A bounded error rate alone is not success if old work is not draining.
+
+Transient proof failures preserve `retry_count` and the previous `last_error`;
+`last_retry_at` now advances to schedule the next attempt. The current error is
+in sanitized application logs. Eligible proofs are ordered by last attempt or
+creation time. Persistent HTTP 500 or unreadable responses can keep individual
+proofs pending indefinitely, so investigate growing queue age even if retry
+counts remain unchanged. Dependency-level logs are filtered for credential
+privacy; do not enable them casually on a credential-bearing endpoint.
+
+Pause further rollout and investigate if startup repeatedly fails, queue age
+keeps rising without recovery, or healthy proof/ciphertext progress stops.
+Use the release's existing rollback procedure if needed. Restore the previous
+sender image and its matching Gateway URL configuration together: a previous
+WebSocket-only sender may require WSS. Leave listener configuration intact and
+preserve queued database work. No schema rollback is needed. Sender rollback
+behavior against the target Gateway is not established by this campaign.
+
+## Dependency exception and remaining scope
+
+`RUSTSEC-2026-0258` is **not server-only**. The upstream advisory describes a
+low-severity denial of service affecting HTTP/2 clients or servers when incoming
+bodies are not fully drained and a malicious direct peer sends excessive empty
+DATA frames. Alloy HTTP 1.1.2 normally reads the response body immediately via
+`resp.bytes().await`; this is not proof of immunity. Keep the existing temporary
+exception visible and remove it after all affected h2 dependencies are migrated
+to a patched version (0.4.16 or later). See the
+[upstream advisory](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h).
+The ruint exception also remains temporary, pending upgrade to 1.20.0 or later.
+
+Accepted-but-unmined nonce reconciliation, finite-cap ciphertext infrastructure
+retry handling, additional RPC error shapes, production mixed-contract capacity
+and automatic application resubmission remain outside this patch's guarantees.
+See the [campaign record](transaction-sender-validation-campaign-2026-09-11.md)
+and [test protocol](transaction-sender-http-proof-retry-test-protocol.md).
+
+## Local rollout checks
+
+Helm lint passed. Rendering with sender and listener enabled verified a literal
+HTTPS sender override, a secret-reference override, and the shared WSS fallback.
+In both override cases the listener retained its WSS setting. These checks use
+synthetic values; they do not verify the actual deployment values or secrets.

--- a/docs/transaction-sender-validation-campaign-2026-09-11.md
+++ b/docs/transaction-sender-validation-campaign-2026-09-11.md
@@ -1,0 +1,202 @@
+# Transaction sender validation campaign — 2026-09-11
+
+Candidate: `c353ee772`, on transport `67762d493` and retry accounting `0fab89ce1`.
+Protocol: [proof retry reliability](transaction-sender-http-proof-retry-test-protocol.md).
+
+## Execution started
+
+Artifacts are retained locally at `/tmp/fhevm-validation-c353ee772/`.
+The Gateway credential file is read directly by the harness; credentials are
+not copied into this document or passed as command-line arguments.
+
+| Lane | Scope | Artifact |
+| --- | --- | --- |
+| Sender regression | Full transaction-sender package, release/locked, two test threads | `full-sender.log` |
+| Stack | Standard e2e profiles; candidate binary copied into local sender container and SHA-256 matched | `e2e-standard.log` |
+| Extended retry matrix | HTTP 408/429/500/502/503/504 at estimate, nonce read and send; 18 cases | `retry-matrix.log` |
+| Long outages | Two five-minute submission outages, removal enabled and disabled, max retries 15 and initial count 14 | `retry-matrix.log` |
+| Gateway performance | Pilot, HTTP batches 1/10/40/80 with two loops, batch 128 with one loop; WSS comparisons at 10/40/128; three-key HTTP; ten-minute HTTP soak | `performance-status.log`, individual run logs |
+
+Retry cases audit every proof-row update/deletion with a database trigger,
+require unchanged retry eligibility during the fault, observe repeated attempts,
+check bounded backoff and require the matching contract event after recovery.
+The recovery deadline is 20 seconds after fault removal. These tests use real
+sender code with Anvil and PostgreSQL; they do not inject faults into Conduit.
+
+Gateway preflight confirmed chain 10900 and latest = pending on all three
+accounts. Performance runs use zero-value transfers, 20-second warmup and
+60-second measurement except the short pilot and 600-second soak. Single-key
+runs use account index 1; the multi-key run uses all three. A campaign-specific
+copy of the retained driver enforces attempt and reserved gas-spend limits,
+drains active tasks at the end, suppresses raw error samples and reports
+successful receipt throughput. The original driver remains untouched.
+The aggregate spend ceiling is 0.08 ETH, with a maximum reservation of 0.03 ETH
+per run. The runner stops on failed tests or an account with unmined work at rest.
+Account balance/nonce snapshots are retained without keys or endpoint URLs.
+
+## Interpretation and remaining gates
+
+Execution has started; this record is not a passing release gate. Results will
+be recorded after completion. Transfer benchmarks measure transport/submission
+capacity; they do not establish mixed proof/ciphertext capacity on Conduit.
+Error counters from the retained driver include warmup and drain; measured
+successful receipt throughput is restricted to the measurement window.
+
+The extended matrix does not cover the entire protocol: baseline negative
+controls, selective-failure fairness, database-preserving restarts across mixed
+operations, client/relayer expiry and retry races, and deployed OTLP inspection
+still require dedicated cases. Standard e2e success must not be substituted for
+those fault scenarios. Accepted-but-unmined nonce recovery remains deferred.
+
+## Interim status
+
+Standard e2e passed in 839 seconds. The sender suite passed 32 tests before
+one AWS KMS gas-estimation failure stopped the run; the failed test and
+remaining proof suites are queued for rerun. The extended retry harness had
+a usize/u64 compilation mismatch; corrected, with execution queued again.
+
+HTTP measured goodput: 189.3 tx/s at batch 10 × 2, 492.6 at 40 × 2,
+533.1 at 80 × 2, and 482.1 at 128 × 1. All these HTTP runs had zero
+errors, including warmup and drain. WSS batch 128 × 1 measured 3.07 successful
+receipts/s and 609 send timeouts across warmup, measurement and drain.
+It left pending work at the eight-second rest check, stopping the campaign.
+A later read confirmed all three accounts had drained naturally; no nonce
+repair was performed. The three-key run and HTTP soak are now resuming,
+retaining the original aggregate spend accounting.
+
+## Latest completed results
+
+- All 70 distinct sender regression tests passed across the initial run and
+  targeted continuation. The previously failing AWS KMS estimation test passed
+  on rerun; its initial intermittent failure remains recorded, not erased.
+- Extended retry matrix: 20/20 passed in 898.94 seconds, including both
+  five-minute outages with database transition auditing.
+- Three-key HTTP: 552.825 successful receipts/s, 44,160 successful transactions
+  including warmup/drain, zero errors.
+- The intended ten-minute soak was invalidated by the harness reservation
+  ceiling: 59,520 successful transactions, zero RPC errors, then submission
+  stopped before the measurement timer ended. Its 92.733 tx/s aggregate is
+  not a valid sustained-load throughput measurement. A complete ten-minute
+  soak at the intended concurrency remains outstanding.
+- Total Gateway spend through this attempt: 0.05171878324 ETH. Nonce deltas
+  account for 244,265 transactions; all three accounts had latest = pending
+  at the final snapshot.
+
+The launched processes have finished. No release-ready verdict is established:
+the full-duration soak and the dedicated protocol gaps above remain open.
+
+## Continuation with reviewed commits locked
+
+The reviewed commits are `4b14c0a9f`, `d2fbe5142`, and `2d335dd89`.
+All continuation changes are test harnesses and documentation on top of that
+history. Runtime source is unchanged. Artifacts for this continuation live in
+`/tmp/fhevm-validation-locked/`.
+
+The revised performance budget retains the maximum reservation for every
+outstanding or ambiguous submission. A mined receipt replaces its reservation
+with `gas_used * effective_gas_price`; an estimation failure releases its
+reservation because no submission was attempted. Transactions exceeding the
+assumed maximum gas limit are not submitted. The accounting unit test checks
+that confirmed receipts refund headroom while ambiguous work stays reserved.
+The soak rerun has a 0.028 ETH cap within the original campaign's remaining
+budget. It is a 20-second warmup plus 600 measured seconds at batch 10 × 2.
+Builds for other validation lanes share this host, so its throughput is not an
+isolated capacity measurement.
+
+### Finding: selective failures block subsequent proof batches
+
+`gateway_mixed_campaign_tests` failed its fairness assertion after completing
+all cleanup/recovery checks. The fault proxy returned HTTP 503 only for gas
+estimation of proof IDs 1–10. There were initially 30 proofs, another 10 added
+on each of two restarts, and 10 ciphertext digests per cycle. Proofs included
+verification and rejection responses and started one retry below exhaustion.
+
+- All ten affected proofs retained retry count 14 of 15. A database trigger
+  observed no update/deletion of those proofs during the fault.
+- Ciphertext work drained during each outage cycle.
+- Healthy later proof completions were `[0, 0, 0]` across the three cycles.
+- After fault removal, all 50 distinct proof IDs had matching contract events
+  and the proof queue drained within the declared 60-second recovery bound.
+
+The cause is selection by `ORDER BY zk_proof_id LIMIT batch_limit` together
+with unchanged eligibility for the earliest failing batch. Restarts preserve
+that ordering. This is a failed selective-failure fairness gate, not proof loss
+or a cross-operation ciphertext stall. The review must explicitly address this
+limitation; no production change was made to hide or resolve the failure.
+
+The relayer's existing `input_proof_v2_test` suite passed 49/49 tests in 24.68
+seconds, including timeout, deduplication, and retry-after-failure. It runs with
+a mock Gateway. The application's deployed SDK version and finite retry policy
+are still needed to define full-stack client-recovery acceptance.
+
+### Harness corrections and additional controls
+
+One continuation soak accidentally selected the old Rust test executable. Its
+preflight filter ran zero tests but returned success; that run stopped at the
+old reservation ceiling after 55,550 successful transactions (0.0116655 ETH).
+It is invalid as a sustained soak. The runner now requires exactly one passing
+reservation test before any Gateway calls. A negative check confirmed that it
+rejects the old executable. A new run uses the corrected executable, whose
+SHA-256 and driver source hash are saved in `soak-confirmed/metadata.json`.
+This separate load-driver binary was built with Rust 1.97.1; the release
+regression builds use the engine's pinned Rust 1.91.1.
+
+To cover the repeated run, the campaign's self-imposed aggregate ceiling was
+raised to 0.10 ETH, with 0.028 ETH reserved for the new soak. The user-funded
+accounts had sufficient balance; no refill was requested.
+
+The baseline worktree and candidate initially shared Cargo artifacts, producing
+invalid compile failures. After the baseline finished, the candidate's common
+library was explicitly rebuilt before rerunning validation. Future baseline
+builds should use a separate `CARGO_TARGET_DIR` and the pinned toolchain. These
+compile failures are harness problems, not runtime regression findings.
+
+The transport-only negative control at `4b14c0a9f`, with candidate test/proxy
+files copied into its worktree and runtime code untouched, failed all four
+selected preservation assertions for submission HTTP 500/502/503/504. Rows
+reached retry count 15 rather than remaining at 14, so they were ineligible.
+The cases include both removal settings. The assertions fail upon exhaustion;
+this control does not independently wait for the subsequent deletion pass.
+
+An additional relayer test passed in 4.63 seconds: identical input deduplicates
+before server expiry; after expiry it creates a new job that succeeds, while
+the original job remains failed. It uses a two-second server timeout and
+one-second scheduler cadence with a mock Gateway. This adds one distinct
+passing case to the earlier 49, without claiming deployed-client acceptance.
+
+## Continuation results
+
+| Check | Result |
+| --- | --- |
+| Corrected ten-minute HTTP soak, batch 10 × 2 | Passed: 107,400 measured successful transactions, 178.999 tx/s, p50 98.3 ms, p99 259.2 ms |
+| Soak warmup + measurement + drain | 111,280 successful transactions, zero errors/reverts/timeouts, 0 unmined; cost 0.0233688 ETH |
+| Additional audited fault/recovery cases | 6/6 passed in 219.58 seconds: unanswered estimate, local send timeout, Conduit deadline, RPC unavailable, HTTP disconnect before estimate/send forwarding |
+| Extended retry campaign total | 26 distinct passing cases including the earlier 20 and both five-minute outages |
+| JSON and actual OTLP/gRPC export | Passed: positive control present in both sinks, no synthetic credential markers |
+| Transport/privacy regression rerun | 8/8 passed |
+| Relayer input-proof tests | 50 distinct passing tests across the original suite and the new expiry/resubmission case |
+| Negative control | All four selected baseline cases failed the preservation assertion as intended |
+| Selective-failure fairness | Failed; preservation, ciphertext progress, and post-outage recovery passed |
+
+Total Gateway campaign spend, including invalidated attempts, is
+**0.08675308324 ETH** across **411,095 transactions by confirmed nonce delta**.
+The final account snapshots show latest = pending on all three accounts and
+0.33632946026 ETH remaining in total. No refill was needed.
+
+The Python soak runner now also requires all outcome counters to be present,
+zero errors, and a successful-receipt count matching confirmed nonce progress.
+These acceptance checks were verified against the completed soak's captured
+outcomes/account snapshots; they do not require another funded run.
+
+The campaign is not an all-green release gate: selective failures can starve
+later proofs, and deployment-specific client/SDK retry guarantees remain
+unvalidated pending the actual client policy. Local mock-relayer and OTLP
+checks do not replace full-stack client-outage races or inspection of the
+actual deployment's collector configuration. Production-path mixed contract
+capacity and deferred nonce reconciliation are also outside these results.
+
+The mixed-workload test was repeated with the pinned Rust 1.91.1 toolchain:
+it reproduced the same fairness failure in 29.94 seconds, with all 50 proofs
+recovered after fault removal and later completions `[0, 0, 0]` during faults.
+Formatting with the pinned formatter, Python syntax checks, and diff whitespace
+checks passed. Harness usage is documented in the sender's `scripts/README.md`.

--- a/docs/transaction-sender-validation-campaign-2026-09-11.md
+++ b/docs/transaction-sender-validation-campaign-2026-09-11.md
@@ -1,6 +1,13 @@
 # Transaction sender validation campaign — 2026-09-11
 
-Candidate: `c353ee772`, on transport `67762d493` and retry accounting `0fab89ce1`.
+Latest status: the reproduced proof-starvation finding is fixed in `15ce75f88`
+and the strengthened mixed campaign passes. The unreadable-response follow-up
+also passes all nine new recovery cases. See the remediation sections below.
+Earlier failures and commit IDs are retained as campaign history; performance
+and full-stack results apply to their recorded binaries, not automatically to
+these later changes.
+
+Initial candidate: `c353ee772`, on transport `67762d493` and retry accounting `0fab89ce1`.
 Protocol: [proof retry reliability](transaction-sender-http-proof-retry-test-protocol.md).
 
 ## Execution started
@@ -301,3 +308,44 @@ cancellation. The final implementation drains all batch tasks, and the test
 allows twelve seconds for shutdown (send timeout plus operation backoff).
 Logs: `fairness-mixed.log` and `fairness-mixed-final.log` under the campaign
 artifact directory.
+
+## Unreadable-response remediation and regression results
+
+Alloy deserialization failures now preserve proof work through the same fair
+scheduling path. This includes HTTP 200 maintenance HTML, empty bodies and
+malformed JSON. The diagnostic test now expects the proof's previous stored
+error to remain unchanged for these failures; response contents stay omitted.
+
+Nine new proxy cases **passed in 259.77 seconds**: each of the three response
+shapes at estimation, nonce lookup and submission, with cleanup enabled and
+retry count 14 of 15. Each audited protected fields throughout repeated
+failures, checked bounded attempt rate, and required recovery contract evidence.
+The updated real logs/DB privacy test passed in 8.19 seconds; six library tests
+passed, including existing terminal error classification controls. The fairness
+implementation passed all 33 proof regressions (private-key and AWS KMS cases)
+in 249.60 seconds. Targeted Clippy with CI warning flags, pinned formatting,
+changed-file spelling checks and diff whitespace checks passed.
+
+The mixed campaign's healthy completion totals were `[20, 30, 40]`, with every
+healthy row drained before each restart/fault-removal boundary. The final
+50-event assertion includes the ten initially failing proofs after recovery.
+Artifacts: `unreadable-recovery.log`, `unreadable-diagnostics.log`,
+`fairness-proof-regressions.log`, `fairness-unit.log` and `fairness-clippy.log`
+under `/tmp/fhevm-validation-locked/`. No funded Gateway test was required for
+these changes. Production-path capacity and accepted-but-unmined nonce recovery
+remain outside this validation.
+
+The five-minute HTTP 503 submission outage rerun **passed in 306.25 seconds**
+with cleanup enabled and the proof initially at retry count 14 of 15. The proof
+retained its budget and protected fields, made bounded retries, and completed
+after fault removal. Log: `fairness-long-outage.log`.
+
+Additional review boundaries: add-ciphertext retains its existing Alloy-based
+limited/unlimited classification. HTTP connect/timeouts and statuses such as
+500/502/504 can consume its limited counter; a finite configured cap can thus
+make work ineligible. The deployed effectively unbounded cap mitigates this
+exhaustion risk, but this follow-up does not fix finite-cap behavior. Likewise,
+proof handling of `NullResp` and HTTP statuses outside the explicit allowlist
+is unchanged; this patch does not claim all possible infrastructure response
+shapes are covered. Future classifier expansion requires reachability and
+preservation/fairness tests rather than broad RPC-message matching.

--- a/docs/transaction-sender-validation-campaign-2026-09-11.md
+++ b/docs/transaction-sender-validation-campaign-2026-09-11.md
@@ -200,3 +200,30 @@ it reproduced the same fairness failure in 29.94 seconds, with all 50 proofs
 recovered after fault removal and later completions `[0, 0, 0]` during faults.
 Formatting with the pinned formatter, Python syntax checks, and diff whitespace
 checks passed. Harness usage is documented in the sender's `scripts/README.md`.
+
+## Deployed SDK/readiness clarification
+
+The deployment owner supplied `@zama-fhe/sdk@3.5.1` → `@fhevm/sdk@0.13.2`
+(commit `07fb05fb7`), relayer v0.13.4 and rollback v0.13.0. This resolves the
+version/configuration question above. Source comparison confirms that the
+SDK async-request implementation matches this branch, and that the readiness
+loop and example retry settings match all three relayer tags v0.13.0/.2/.4.
+The SDK throws on the relayer's terminal 503; its one-hour deadline does not
+retry that result. Approximately 225 seconds describes the relayer readiness
+budget, not an application retry limit (74 three-second sleeps plus RPC time).
+
+The prior input-proof expiry test covers a different state machine. The test
+protocol now includes section C for decryption readiness, the final-attempt
+race, actual SDK terminal-error behavior and explicit fresh calls after
+recovery, for both relayer versions. Those full-stack scenarios remain unrun;
+no automatic application resubmission guarantee is inferred from SDK polling.
+This clarification does not change the passing sender preservation results
+or resolve the observed selective-failure starvation gate.
+
+Focused readiness regression: `test_readiness_timeout_returns_503_with_correct_label`
+passed (1/1, 0.91 seconds) with Rust 1.91.1 and `--features integration-tests`.
+It uses a mock Gateway and two attempts separated by 50 ms, asserting HTTP
+503 and the exact readiness label. It does not exercise the SDK or the deployed
+window. The first invocation omitted the integration-test feature and failed
+to compile the optional mock dependency; the corrected invocation passed.
+Artifact: `/tmp/fhevm-validation-locked/relayer-readiness-boundary.log`.

--- a/docs/transaction-sender-validation-campaign-2026-09-11.md
+++ b/docs/transaction-sender-validation-campaign-2026-09-11.md
@@ -227,3 +227,57 @@ It uses a mock Gateway and two attempts separated by 50 ms, asserting HTTP
 window. The first invocation omitted the integration-test feature and failed
 to compile the optional mock dependency; the corrected invocation passed.
 Artifact: `/tmp/fhevm-validation-locked/relayer-readiness-boundary.log`.
+
+## SDK readiness campaign continuation
+
+The actual SDK async-request source at `07fb05fb7` was executed with Bun 1.3.14
+against real relayer HTTP handlers and a mock Gateway. The app wrapper and
+cryptographic decryption are outside these focused tests.
+
+| Test | Result |
+| --- | --- |
+| Relayer v0.13.4, 75 attempts × 3 s, SDK defaults | Passed: 75 false readiness observations, one POST, 28 GETs, terminal 503 at 224.096 s |
+| Relayer v0.13.0 rollback, same SDK/config | Passed: 75 false readiness observations, one POST, 28 GETs, terminal 503 at 224.093 s |
+| SDK default Retry-After and one-second floor | 2/2 passed against a local HTTP fixture; each stops on 503 without another POST |
+| Final readiness attempt and fresh identical request after exhaustion | Passed in 6.20 s using four attempts at 250 ms: final-attempt success; after exhaustion a new job succeeds and the original stays failed |
+
+Both unscaled cases observe an additional three seconds after rejection with
+no further SDK requests. The HTTP count reflects this fixture's server ETA,
+not the incident's polling cadence. Rollback validation used a separate v0.13.0
+worktree and Cargo artifacts, adding only the test and runner; runtime source
+was unchanged. Logs are `sdk-relayer-readiness.log`,
+`sdk-relayer-rollback-readiness.log`, `sdk-polling.log` and
+`readiness-final-attempt.log` in `/tmp/fhevm-validation-locked/`. Commands and
+prerequisites are in `relayer/tests/campaign/README.md`.
+
+The real-stack e2e container initially had SDK 0.13.2-0. Installing with npm
+workspace discovery did not expose the requested package to the e2e suite;
+repeating with `--workspaces=false` installed and resolved exact SDK 0.13.2.
+The initial real-stack attempt failed during encryption-key fetch because
+the relayer was still starting after configuration reload. The harness restored
+the sender and original configuration, and now checks that the relayer accepts
+HTTP requests before starting. This initial failure is not a readiness result.
+
+The corrected real-stack public-decryption case **passed** (one case, 235.8 s).
+It used the HTTP sender already installed in the local stack, relayer image
+`ghcr.io/zama-ai/fhevm/relayer:8234edf` (v0.13.4), exact published SDK 0.13.2,
+and real local contracts/workers/KMS. The sender was paused before creating
+new ciphertexts, holding registration through the full readiness window.
+The SDK returned the expected readiness error at 224.131 s. After unpausing
+the sender, one explicit fresh call for the same ciphertext returned the
+correct boolean plaintext at 233.200 s, 9.069 s after the terminal observation.
+The watchdog reported three ciphertexts, zero divergence and zero stalled
+pending items. The original runtime configuration was restored and the sender
+was verified unpaused. Logs: `full-stack-readiness.log`, `full-stack-runner.log`;
+source hashes and image digest: `readiness-metadata.json`. No funded Gateway
+transactions were made in this continuation.
+
+Remaining boundaries: the full-stack case covers public decryption on v0.13.4
+with a fully paused sender, not user decryption or rollback full-stack behavior,
+and not selective RPC failure. Rollback/user-decryption coverage above is
+SDK-to-real-relayer with a mock Gateway. Application wrapper 3.5.1 automatic
+resubmission remains untested and is not inferred. Real-stack recovery before
+the final readiness check and repeated outage/restart races remain unrun.
+The known later-proof starvation failure remains unresolved. None of these
+results establish deferred nonce reconciliation safety or production-path
+mixed-contract capacity.

--- a/docs/transaction-sender-validation-campaign-2026-09-11.md
+++ b/docs/transaction-sender-validation-campaign-2026-09-11.md
@@ -281,3 +281,23 @@ the final readiness check and repeated outage/restart races remain unrun.
 The known later-proof starvation failure remains unresolved. None of these
 results establish deferred nonce reconciliation safety or production-path
 mixed-contract capacity.
+
+## Fairness remediation
+
+The new scheduling patch uses existing timestamps for persistent per-proof
+deferral and oldest-attempt/creation ordering. It preserves finite retry count
+and stored error, and drains mixed batches before returning task errors. No
+schema migration or nonce-recovery redesign is included. Protected-field audits
+now permit only `last_retry_at` updates during transient failure.
+
+The strengthened mixed test **passed in 54.31 seconds**: healthy work drained
+during all three selective-failure cycles, new proofs arrived at 200 ms
+intervals, deferred proofs received repeated attempts, two restarts completed,
+and all 50 proofs ultimately had matching contract events. This supersedes
+the earlier `[0, 0, 0]` starvation finding for the patched code.
+The first scheduling-only attempt failed on graceful-shutdown timeout while
+submissions were still active; inspection also exposed early-error batch
+cancellation. The final implementation drains all batch tasks, and the test
+allows twelve seconds for shutdown (send timeout plus operation backoff).
+Logs: `fairness-mixed.log` and `fairness-mixed-final.log` under the campaign
+artifact directory.

--- a/relayer/tests/campaign/README.md
+++ b/relayer/tests/campaign/README.md
@@ -1,0 +1,47 @@
+# SDK/readiness campaign
+
+Run from `relayer/` with its pinned Rust toolchain. Install the SDK source
+checkout's dependencies first (`cd ../sdk/js-sdk && npm ci --ignore-scripts`).
+The SDK `RelayerAsyncRequest.ts` must match commit `07fb05fb7`; verify with
+`git diff 07fb05fb7 -- ../sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.ts`.
+Bun is required. These tests use real HTTP and a real relayer with the existing
+mock Gateway and test database, not a complete FHE stack or the application wrapper.
+
+```sh
+bun test tests/campaign/sdk-polling.test.ts
+cargo test --locked --features integration-tests --test user_decrypt_v2_test test_campaign_readiness_final_attempt_and_fresh_request -- --ignored --exact --nocapture
+cargo test --locked --features integration-tests --test user_decrypt_v2_test test_campaign_sdk_deployed_readiness_window -- --ignored --exact --nocapture
+```
+
+The unscaled test takes approximately four minutes. It configures 75 readiness
+attempts with three-second intervals, invokes the SDK with default retry/timeout
+options, requires the terminal 503 label, records every HTTP status and method,
+and observes three further seconds without another request. The short boundary
+test controls the number of failed readiness observations, then tests an explicit
+identical fresh request after exhaustion. Its successful mock result does not
+establish cryptographic plaintext correctness.
+
+For rollback validation use a separate checkout and Cargo target directory.
+Copy only the unscaled test and its SDK runner into v0.13.0, pointing the runner
+at the same verified SDK source. Do not replace rollback runtime source or share
+Cargo build artifacts across checkouts. Preserve each complete log separately.
+
+## Real-stack public decryption
+
+`test-suite/e2e/test/readinessCampaign/readinessCampaign.ts` is opt-in via
+`READINESS_CAMPAIGN=1`. Run only on the disposable local stack. Before running,
+verify SDK 0.13.2 is installed in the e2e container and record the relayer image
+digest. Save the runtime relayer YAML, set readiness to 75 attempts/3000 ms,
+restart, and wait until HTTP accepts requests. Pause the sender before deploying
+the test contract. The test writes `/tmp/readiness-campaign-resume` inside the
+e2e container after observing the terminal readiness error. Resume the sender,
+then create `/tmp/readiness-campaign-resumed` in that container. The test makes
+one fresh decryption call and checks the plaintext. Remove both marker files
+before each run. Always resume the sender and restore/restart the original
+relayer configuration in a finally/trap handler, including on test failure.
+
+Run the single test with `npx hardhat test --no-compile --network staging
+test/readinessCampaign/readinessCampaign.ts` in the initialized e2e container.
+The campaign's exact host runner and logs are retained under
+`/tmp/fhevm-validation-locked/`. This pauses the entire sender; it does not
+inject selective RPC failures or establish nonce recovery safety.

--- a/relayer/tests/campaign/sdk-polling.test.ts
+++ b/relayer/tests/campaign/sdk-polling.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from 'bun:test';
+import { RelayerAsyncRequest } from '../../../sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.ts';
+
+for (const [retryAfter, minimumMs] of [
+  [undefined, 2500],
+  ['0', 1000],
+] as const) {
+  test(`SDK polls 202 with Retry-After=${retryAfter ?? 'absent'} and stops on 503`, async () => {
+    const calls: Array<{ method: string; at: number }> = [];
+    const server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch(request) {
+        calls.push({ method: request.method, at: performance.now() });
+        const headers = retryAfter === undefined ? {} : { 'Retry-After': retryAfter };
+        if (request.method === 'POST') {
+          return Response.json(
+            { status: 'queued', requestId: 'request', result: { jobId: 'job' } },
+            { status: 202, headers },
+          );
+        }
+        if (calls.length === 2) {
+          return Response.json({ status: 'queued', requestId: 'request' }, { status: 202, headers });
+        }
+        return Response.json(
+          { status: 'failed', error: { label: 'readiness_check_timed_out', message: 'Readiness exhausted' } },
+          { status: 503 },
+        );
+      },
+    });
+    try {
+      const request = new RelayerAsyncRequest({
+        relayerOperation: 'USER_DECRYPT',
+        url: `${server.url}v2/user-decrypt`,
+        payload: {},
+      });
+      let failure: any;
+      try {
+        await request.run();
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure?.status).toBe(503);
+      expect(failure?.relayerApiError?.label).toBe('readiness_check_timed_out');
+      expect(calls.map((c) => c.method)).toEqual(['POST', 'GET', 'GET']);
+      for (let i = 1; i < calls.length; i++) {
+        expect(calls[i].at - calls[i - 1].at).toBeGreaterThanOrEqual(minimumMs - 25);
+      }
+      await Bun.sleep(1100);
+      expect(calls.length).toBe(3);
+    } finally {
+      server.stop(true);
+    }
+  }, 15000);
+}

--- a/relayer/tests/campaign/sdk-readiness.ts
+++ b/relayer/tests/campaign/sdk-readiness.ts
@@ -1,0 +1,32 @@
+// Run through the deployed SDK's unchanged async-request implementation.
+// This exercises transport/result handling, not cryptographic SDK validation.
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { RelayerAsyncRequest } from '../../../sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.ts';
+
+const [url, payloadPath] = process.argv.slice(2);
+const calls: Array<{ method: string; status: number; elapsedMs: number }> = [];
+const originalFetch = globalThis.fetch;
+const started = performance.now();
+globalThis.fetch = async (input, init) => {
+  const response = await originalFetch(input, init);
+  calls.push({ method: init?.method ?? 'GET', status: response.status, elapsedMs: performance.now() - started });
+  return response;
+};
+try {
+  await new RelayerAsyncRequest({
+    relayerOperation: 'USER_DECRYPT',
+    url,
+    payload: JSON.parse(readFileSync(payloadPath, 'utf8')),
+  }).run();
+  assert.fail('Expected terminal readiness error');
+} catch (error: any) {
+  assert.equal(error.status, 503);
+  assert.equal(error.relayerApiError?.label, 'readiness_check_timed_out');
+}
+assert.equal(calls.filter((c) => c.method === 'POST').length, 1);
+assert.equal(calls.at(-1)?.status, 503);
+const terminalCount = calls.length;
+await Bun.sleep(3000);
+assert.equal(calls.length, terminalCount, 'SDK must not silently resubmit after terminal 503');
+console.log(JSON.stringify({ calls, elapsedMs: performance.now() - started }));

--- a/relayer/tests/input_proof_v2_test.rs
+++ b/relayer/tests/input_proof_v2_test.rs
@@ -875,3 +875,47 @@ async fn test_error_malformed_json(#[case] malformed_json: &str) {
 
     setup.shutdown().await;
 }
+
+/// Campaign control: client retries before server expiry are deduplicated;
+/// the same input after expiry must dispatch a fresh job and complete.
+#[tokio::test]
+async fn test_campaign_retry_across_server_expiry_completes_same_input() {
+    let temp = TempDir::new().unwrap();
+    let config = create_timeout_test_config(&temp, 2, 1).unwrap();
+    let setup = TestSetup::new_with_config_path(Some(config)).await.unwrap();
+    let (payload, user, data) = helpers::create_input_proof_payload(&setup);
+    setup
+        .fhevm_mock
+        .on_input_proof_request_only(user, data.clone());
+    let original = helpers::submit_request(&setup, &payload).await;
+    let duplicate = helpers::submit_request(&setup, &payload).await;
+    assert_eq!(
+        original, duplicate,
+        "retry before server expiry bypassed deduplication"
+    );
+    let (status, expired) = helpers::poll_until_terminal(&setup, &original).await;
+    assert_eq!(status, reqwest::StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(expired.status, ApiResponseStatus::Failed);
+    setup.fhevm_mock.on_input_proof_success(
+        user,
+        data,
+        1,
+        ethereum_rpc_mock::SubscriptionTarget::All,
+    );
+    let replacement = helpers::submit_request(&setup, &payload).await;
+    assert_ne!(
+        original, replacement,
+        "server expiry did not allow fresh work"
+    );
+    let (status, result) = helpers::poll_until_terminal(&setup, &replacement).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(result.status, ApiResponseStatus::Succeeded);
+    assert!(result.result.is_some());
+    let (_, original_result) = helpers::poll_until_terminal(&setup, &original).await;
+    assert_eq!(
+        original_result.status,
+        ApiResponseStatus::Failed,
+        "replacement changed the old job's result"
+    );
+    setup.shutdown().await;
+}

--- a/relayer/tests/user_decrypt_v2_test.rs
+++ b/relayer/tests/user_decrypt_v2_test.rs
@@ -2159,3 +2159,107 @@ async fn test_wait_window_expiry_returns_all_collected() {
 
     setup.shutdown().await;
 }
+
+/// Actual SDK HTTP handling against a real relayer and mock Gateway.
+/// Run explicitly; requires Bun and sdk/js-sdk dependencies installed.
+#[tokio::test]
+#[ignore = "extended SDK readiness campaign"]
+async fn test_campaign_sdk_deployed_readiness_window() {
+    let dir = TempDir::new().unwrap();
+    let mut config: serde_yaml::Value =
+        serde_yaml::from_str(&std::fs::read_to_string("tests/relayer-test-config.yaml").unwrap())
+            .unwrap();
+    config["gateway"]["readiness_checker"]["gw_ciphertext_check"]["retry"]["max_attempts"] =
+        75.into();
+    config["gateway"]["readiness_checker"]["gw_ciphertext_check"]["retry"]["retry_interval_ms"] =
+        3000.into();
+    let config_path = dir.path().join("readiness.yaml");
+    std::fs::write(&config_path, serde_yaml::to_string(&config).unwrap()).unwrap();
+    let setup = TestSetup::new_with_config_path(Some(config_path))
+        .await
+        .unwrap();
+    setup.fhevm_mock.set_readiness_failure();
+    let payload = helpers::create_user_decrypt_payload(
+        &setup.settings.gateway.blockchain_rpc.chain_id.to_string(),
+        helpers::random_address(),
+        helpers::random_address(),
+    );
+    let payload_path = dir.path().join("payload.json");
+    std::fs::write(&payload_path, serde_json::to_vec(&payload).unwrap()).unwrap();
+    let started = std::time::Instant::now();
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(360),
+        tokio::process::Command::new("bun")
+            .arg("tests/campaign/sdk-readiness.ts")
+            .arg(helpers::v2_user_decrypt_post_url(&setup))
+            .arg(payload_path)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .expect("SDK readiness campaign exceeded 360 seconds")
+    .unwrap();
+    println!("SDK campaign: {}", String::from_utf8_lossy(&output.stdout));
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(started.elapsed() >= std::time::Duration::from_secs(222));
+    setup.shutdown().await;
+}
+
+#[tokio::test]
+#[ignore = "extended readiness boundary campaign"]
+async fn test_campaign_readiness_final_attempt_and_fresh_request() {
+    for failures in [3, 4] {
+        let setup = TestSetup::new_with_fast_readiness().await.unwrap();
+        setup
+            .fhevm_mock
+            .set_readiness_success_after_n_failures(failures);
+        let user_address = helpers::random_address();
+        let payload = helpers::create_user_decrypt_payload(
+            &setup.settings.gateway.blockchain_rpc.chain_id.to_string(),
+            helpers::random_address(),
+            user_address,
+        );
+        setup.fhevm_mock.on_user_decrypt_success_with_share_count(
+            UserDecryptKind::Direct,
+            helpers::extract_ciphertext_handles_from_user_payload(&payload),
+            user_address,
+            ethereum_rpc_mock::SubscriptionTarget::All,
+            9,
+        );
+        let original = helpers::submit_request(&setup, &payload).await;
+        let (status, body) = helpers::poll_until_terminal_within(
+            &setup,
+            &original,
+            std::time::Duration::from_secs(20),
+        )
+        .await;
+        if failures == 3 {
+            assert_eq!(status, reqwest::StatusCode::OK);
+            assert_eq!(body.status, ApiResponseStatus::Succeeded);
+        } else {
+            assert_eq!(status, reqwest::StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(body.error.unwrap().label(), "readiness_check_timed_out");
+            let fresh = helpers::submit_request(&setup, &payload).await;
+            assert_ne!(
+                original, fresh,
+                "Terminal readiness failure must permit a fresh job"
+            );
+            let (status, body) = helpers::poll_until_terminal_within(
+                &setup,
+                &fresh,
+                std::time::Duration::from_secs(20),
+            )
+            .await;
+            assert_eq!(status, reqwest::StatusCode::OK);
+            assert_eq!(body.status, ApiResponseStatus::Succeeded);
+            let (status, _, body) = helpers::get_status(&setup, &original).await;
+            assert_eq!(status, reqwest::StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(body.error.unwrap().label(), "readiness_check_timed_out");
+        }
+        setup.shutdown().await;
+    }
+}

--- a/test-suite/e2e/test/readinessCampaign/readinessCampaign.ts
+++ b/test-suite/e2e/test/readinessCampaign/readinessCampaign.ts
@@ -1,0 +1,37 @@
+import { assert } from 'chai';
+import { existsSync, writeFileSync } from 'fs';
+import { ethers } from 'hardhat';
+import { createInstances } from '../instance';
+import { getSigners, initSigners } from '../signers';
+
+// Host harness pauses the sender before this test and resumes it after the marker.
+(process.env.READINESS_CAMPAIGN === '1' ? describe : describe.skip)('readiness campaign', function () {
+  this.timeout(420000);
+  it('surfaces readiness expiry then decrypts identical ciphertext after sender recovery', async function () {
+    await initSigners(2);
+    const signers = await getSigners();
+    const instances = await createInstances(signers);
+    const contract = await (await ethers.getContractFactory('HTTPPublicDecrypt')).connect(signers.alice).deploy();
+    await contract.waitForDeployment();
+    const handle = await contract.xBool();
+    const started = Date.now();
+    let failure: any;
+    try {
+      await instances.alice.publicDecrypt([handle]);
+    } catch (error) {
+      failure = error;
+    }
+    assert.exists(failure, 'Registration held through readiness window must fail');
+    assert.include(String(failure), 'readiness_check_timed_out');
+    console.log(JSON.stringify({ stage: 'terminal', elapsedMs: Date.now() - started }));
+    writeFileSync('/tmp/readiness-campaign-resume', 'resume');
+    const deadline = Date.now() + 90000;
+    while (!existsSync('/tmp/readiness-campaign-resumed')) {
+      assert.isBelow(Date.now(), deadline, 'Host did not resume sender');
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    const recovered = await instances.alice.publicDecrypt([handle]);
+    assert.deepEqual(recovered.clearValues, { [handle]: true });
+    console.log(JSON.stringify({ stage: 'recovered', elapsedMs: Date.now() - started }));
+  });
+});

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -180,7 +180,7 @@ services:
     command:
       - transaction_sender
       - --database-url=${DATABASE_URL}
-      - --gateway-url=${GATEWAY_WS_URL}
+      - --gateway-url=${GATEWAY_URL}
       - --private-key=${TX_SENDER_PRIVATE_KEY}
       - --ciphertext-commits-address=${CIPHERTEXT_COMMITS_ADDRESS}
       - --input-verification-address=${INPUT_VERIFICATION_ADDRESS}
@@ -188,7 +188,8 @@ services:
       - --database-polling-interval-secs=20
       - --verify-proof-resp-database-channel=event_zkpok_computed
       - --add-ciphertexts-database-channel=event_ciphertexts_uploaded
-      - --verify-proof-resp-batch-limit=128
+      - --verify-proof-resp-batch-limit=10
+      - --add-ciphertexts-batch-limit=10
       - --verify-proof-resp-max-retries=15
       - --verify-proof-remove-after-max-retries
       - --signer-type=private-key


### PR DESCRIPTION
This hotfix has 3 main parts:
 - move from WSS to HTTP in tx-sender
 - update retry accounting for proof responses to avoid exhaustiung the budget on infra failures.
 - sanitise error logs some pre-existing but which the http migration makes worse (this can be trimmed down if it's too broad, but feels wrong to leave this out)