### PR TITLE
docs(solana): clarify issuer freeze limitations

### DIFF
--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1,6 +1,6 @@
 # Solana PoC Design Decisions
 
-Last synced: 2026-09-10.
+Last synced: 2026-09-11.
 
 This document is the stable rationale index for the Solana FHEVM PoC: why the current design exists.
 Older entries keep the rationale as it stood when they were adopted. For the current account, permission, disclosure
@@ -2145,24 +2145,25 @@ does not check freeze. Redeem destination ownership is not required: the confide
 owner must sign, which is the theft check; `destination_usdc.owner == owner` was only a
 no-unwrap-to-third-party policy and is not enforced.
 
-What this freeze mirror does not reach (fhevm-internal#1981). The issuer's freeze acts on
-SPL token accounts, and the mirror reads the canonical associated token account of each owner. A
-confidential balance is not an SPL account, so two holders escape it:
+What this freeze mirror does not reach (fhevm-internal#1981). Transfer checks both owners' canonical
+underlying ATAs; burn checks the owner's ATA. Wrap and redeem check the SPL source and destination
+accounts they move. These account-level checks do not establish a durable restriction on a holder:
 
 - A holder who never held the underlying: funds arrive as a confidential transfer from a third party
   (an exchange paying out directly into the wrapped mint). No canonical ATA exists, absent reads as
-  not frozen, and the issuer has nothing to freeze.
+  not frozen, and there is no holder ATA for the issuer to freeze. The shared underlying vault
+  remains subject to its own freeze status.
 - A holder who wrapped their entire balance: the canonical ATA is empty, and the issuer freezes an
   empty account. Classic Token and Token-2022 both allow closing a frozen account with a zero
-  balance, so the holder closes it and recreates it unfrozen. The check only bites while the
-  holder keeps a balance on the ATA.
+  balance, so the holder can close it and recreate it unfrozen. The check rejects the frozen ATA
+  while it exists, including when its balance is zero; closure removes that restriction.
 
-This is the same account-level semantics the native tokens have: an SPL freeze never reached
-balances held in a program's own accounts either. What is new is that the wrapper is now such a
-program, holding balances the issuer cannot see or freeze. Closing that gap needs a wrapper-level
-freeze authority (a per-owner frozen flag on the confidential token account, settable by an
-authority the issuer holds or delegates), so the issuer and not Zama decides. That is launch work
-under fhevm-internal#1981, outside this PoC, and a product decision recorded there.
+The PoC retains these checks and their limitations. An issuer-authorized restriction on confidential
+holders is one proposed response in fhevm-internal#1981, not an adopted design. Before launch, product,
+compliance and the issuer must agree on the required behavior, authority authentication and rotation,
+and treatment of pending burns. Neither the host admin nor the wrapper creator is automatically the
+issuer. Host application-deny, pause and upgrade controls remain separate; these checks alone do not
+establish Zama's compliance responsibilities.
 
 Wrap credits use the same saturating `ge → select` pattern as burn debits (`tryIncrease` parity).
 The clamp is unreachable while wrap stays 1:1 with an SPL `u64` vault.

--- a/solana/docs/INVARIANTS.md
+++ b/solana/docs/INVARIANTS.md
@@ -387,13 +387,13 @@ accounts. Classic Token and extension-free Token-2022 are supported.
 Token-2022 mint extensions are rejected unless explicitly allowlisted;
 today none are allowlisted. Token accounts allow only `ImmutableOwner`.
 
-**57. [HOLDS]** Frozen underlying token accounts cannot wrap, confidential-transfer, burn, or
-redeem. Transfer checks both owners' associated token accounts (`from_ata`/`to_ata`); burn
-checks the burner's (`owner_ata`). Uninitialized at that ATA address is treated as not frozen,
-so the mirror does not reach a holder with no canonical ATA (funded by confidential transfer
-only) or one who closed and recreated an empty frozen ATA; see DD-045 and fhevm-internal#1981.
-Wrap and redeem keep checking the
-accounts they actually move. Cancel-pending-burn is not freeze-gated. Token-2022 transfer-fee, transfer-hook,
+**57. [HOLDS]** Each token operation rejects a frozen underlying account that it checks: transfer checks
+both owners' canonical ATAs (`from_ata`/`to_ata`), burn checks the owner's ATA (`owner_ata`), and wrap
+and redeem check the SPL source and destination accounts they move. Redeem does not recheck the
+burner's ATA and may pay a third party. An uninitialized canonical ATA is treated as not frozen;
+an empty frozen ATA can be closed and recreated unfrozen. These are account-level checks, not a
+durable holder denylist; see DD-045 and fhevm-internal#1981 for the unresolved launch decision.
+Cancel-pending-burn has no issuer-freeze check. Token-2022 transfer-fee, transfer-hook,
 non-transferable, and confidential-transfer behavior cannot be inherited
 accidentally because those mint extensions fail closed under #56.
 


### PR DESCRIPTION
Clarify which underlying SPL accounts each confidential-token operation checks and why these checks do not provide a durable holder denylist.
DD-045 and invariant #57 now describe missing ATAs, closure of empty frozen ATAs, and redemption without a burner-ATA recheck; issuer-authorized holder restrictions remain a proposal under zama-ai/fhevm-internal#1981, which stays open.
Host application-deny, pause and upgrade controls remain separate, and no token behavior changes.
Validation: `git diff --check`, `typos`, and built-in Markdown Prettier checks for DD-045 and INVARIANTS pass; full-file DESIGN_DECISIONS formatting has unrelated existing differences, and runtime tests were not run for this documentation-only change.
