### PR TITLE
docs(solana): use glossary wording for holder denylist

### DIFF
--- a/solana/docs/INVARIANTS.md
+++ b/solana/docs/INVARIANTS.md
@@ -392,7 +392,7 @@ both owners' canonical ATAs (`from_ata`/`to_ata`), burn checks the owner's ATA (
 and redeem check the SPL source and destination accounts they move. Redeem does not recheck the
 burner's ATA and may pay a third party. An uninitialized canonical ATA is treated as not frozen;
 an empty frozen ATA can be closed and recreated unfrozen. These are account-level checks, not a
-durable holder denylist; see DD-045 and fhevm-internal#1981 for the unresolved launch decision.
+persistent holder denylist; see DD-045 and fhevm-internal#1981 for the unresolved launch decision.
 Cancel-pending-burn has no issuer-freeze check. Token-2022 transfer-fee, transfer-hook,
 non-transferable, and confidential-transfer behavior cannot be inherited
 accidentally because those mint extensions fail closed under #56.


### PR DESCRIPTION
Replace “durable” with “persistent” in invariant #57 to satisfy the glossary check that failed on #3919.
The holder-denylist limitation and token behavior are unchanged.
Validation: `DEAD_SURFACE_ONLY_CHECK=3 bash scripts/dead-surface-check.sh`, `typos`, and `git diff --check` pass.
