### PR TITLE
chore(test-suite): hardening e2e tests

### DIFF
--- a/ci/preview-env/relayer/values-relayer-e2e.yaml
+++ b/ci/preview-env/relayer/values-relayer-e2e.yaml
@@ -131,7 +131,7 @@ configmapFiles:
       # isValidSignature static call. Its absence aborts startup with
       # 'missing configuration field "user_decrypt_signature_check"'.
       user_decrypt_signature_check:
-        erc1271_gas_limit: 100000
+        erc1271_gas_limit: 250000
       log:
         format: "json"
         show_file_line: true

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -109,10 +109,10 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 
 # Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
 # Bounds resource use when verifying signatures from smart-account users (Safe, Argent,
-# ERC-4337). 100k is the RFC's suggested starting point; tune up for deep multisig
-# thresholds. (optional, defaults to 100000)
+# ERC-4337). A nested Safe (a Safe owning a Safe) costs ~91k; the rest is headroom for
+# deeper nesting, and a call needing more than 100k is logged. (optional, defaults to 250000)
 # ENV: KMS_CONNECTOR_ERC1271_GAS_LIMIT
-# erc1271_gas_limit = 100000
+# erc1271_gas_limit = 250000
 
 # The maximum number of tasks to process events/responses concurrently (optional, defaults to 1000)
 # ENV: KMS_CONNECTOR_TASK_LIMIT

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -110,7 +110,7 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
 # Bounds resource use when verifying signatures from smart-account users (Safe, Argent,
 # ERC-4337). A nested Safe (a Safe owning a Safe) costs ~91k; the rest is headroom for
-# deeper nesting, and a call needing more than 100k is logged. (optional, defaults to 250000)
+# deeper nesting. (optional, defaults to 250000)
 # ENV: KMS_CONNECTOR_ERC1271_GAS_LIMIT
 # erc1271_gas_limit = 250000
 

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -240,7 +240,7 @@ fn default_s3_max_ciphertext_size() -> NonZeroUsize {
 }
 
 fn default_erc1271_gas_limit() -> u64 {
-    100_000
+    250_000
 }
 
 impl DeserializeConfig for Config {}

--- a/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
@@ -105,7 +105,9 @@ impl From<Erc1271Error> for ProcessingError {
                 Self::irrecoverable(ErrorCode::UserSignatureRejected, err)
             }
             Erc1271Error::Transport(_) => Self::transient(err),
-            Erc1271Error::WrongMagic(..) | Erc1271Error::Rejected(..) => {
+            Erc1271Error::WrongMagic(..)
+            | Erc1271Error::Rejected(..)
+            | Erc1271Error::EmptyRevert(_) => {
                 Self::recoverable(ErrorCode::UserSignatureRejected, err)
             }
         }
@@ -201,7 +203,8 @@ impl From<Erc1271Error> for RequestCheckError {
     fn from(err: Erc1271Error) -> Self {
         let kind = match &err {
             Erc1271Error::Transport(_) => RequestCheckKind::Network,
-            Erc1271Error::EmptySigOnEoa(_)
+            Erc1271Error::EmptyRevert(_)
+            | Erc1271Error::EmptySigOnEoa(_)
             | Erc1271Error::EoaMismatchNoCode(_)
             | Erc1271Error::Rejected(..)
             | Erc1271Error::WrongMagic(..) => RequestCheckKind::Signature,

--- a/relayer/config/local.mainnet.yaml.example
+++ b/relayer/config/local.mainnet.yaml.example
@@ -37,7 +37,7 @@ keyurl:
 
 # User-decryption signature check. Gas cap for the ERC-1271 isValidSignature static call.
 user_decrypt_signature_check:
-  erc1271_gas_limit: 100000
+  erc1271_gas_limit: 250000
 
 gateway:
   blockchain_rpc:

--- a/relayer/config/local.testnet.yaml.example
+++ b/relayer/config/local.testnet.yaml.example
@@ -32,7 +32,7 @@ keyurl:
 
 # User-decryption signature check. Gas cap for the ERC-1271 isValidSignature static call.
 user_decrypt_signature_check:
-  erc1271_gas_limit: 100000
+  erc1271_gas_limit: 250000
 
 gateway:
   blockchain_rpc:

--- a/relayer/config/local.yaml.example
+++ b/relayer/config/local.yaml.example
@@ -32,7 +32,7 @@ keyurl:
 
 # User-decryption signature check. Gas cap for the ERC-1271 isValidSignature static call.
 user_decrypt_signature_check:
-  erc1271_gas_limit: 100000
+  erc1271_gas_limit: 250000
 
 gateway:
   blockchain_rpc:

--- a/relayer/src/host/signature_prechecker.rs
+++ b/relayer/src/host/signature_prechecker.rs
@@ -24,7 +24,8 @@ use user_decryption_signature::{
 /// Outcome of a failed pre-check.
 #[derive(Debug, thiserror::Error)]
 pub enum SigPreCheckError {
-    /// The signature is definitively invalid — the request must not be forwarded.
+    /// The signature is invalid, or reverted without a reason on every attempt — either
+    /// way the request must not be forwarded.
     #[error("invalid user-decryption signature for {signer}: {reason}")]
     Invalid { signer: Address, reason: String },
     /// The host-chain call could not complete (transport error after retries). Surfaced as a
@@ -77,8 +78,8 @@ impl UserDecryptSignaturePreChecker {
 
     /// Verify the signature on a unified v3 request. Non-unified variants are a no-op (the
     /// pre-check is wired only into the v3 endpoint). Recomputes the EIP-712 digest, then runs
-    /// the shared verifier, retrying transport errors like the host ACL checks do and rejecting
-    /// only on definitive verification failures.
+    /// the shared verifier, retrying transport failures and reasonless reverts like the host
+    /// ACL checks do, and rejecting on definitive verification failures.
     pub async fn verify(&self, request: &UserDecryptRequest) -> Result<(), SigPreCheckError> {
         let UserDecryptRequest::Eip712UnifiedV1 {
             handles,
@@ -115,7 +116,7 @@ impl UserDecryptSignaturePreChecker {
 
         let max_attempts = self.retry.max_attempts.max(1);
         let interval = Duration::from_millis(self.retry.retry_interval_ms);
-        let mut last_transport_err = String::new();
+        let mut last_retryable: Option<Erc1271Error> = None;
 
         for attempt in 0..max_attempts {
             match verify_signature(
@@ -128,23 +129,24 @@ impl UserDecryptSignaturePreChecker {
             .await
             {
                 Ok(()) => return Ok(()),
-                // Transport errors are non-deterministic — retry like the host ACL checks do.
-                Err(Erc1271Error::Transport(msg)) => {
-                    last_transport_err = msg;
+                // Retry what is not proof of a bad signature: transport failures, and
+                // reasonless reverts, which an under-gassed call produces too.
+                Err(e @ (Erc1271Error::Transport(_) | Erc1271Error::EmptyRevert(_))) => {
                     if attempt + 1 < max_attempts {
                         warn!(
                             signer = %user_address,
                             chain_id,
                             attempt = attempt + 1,
                             max_attempts,
-                            error = %last_transport_err,
+                            error = %e,
                             "Signature pre-check RPC failed, retrying"
                         );
                         tokio::time::sleep(interval).await;
                     }
+                    last_retryable = Some(e);
                 }
                 // Every other variant is a definitive rejection (ecrecover mismatch, wrong/empty
-                // ERC-1271 magic, revert, short returndata). The error Display encodes the path.
+                // ERC-1271 magic, reasoned revert, short returndata). The Display encodes the path.
                 Err(e) => {
                     return Err(SigPreCheckError::Invalid {
                         signer: user_address,
@@ -154,7 +156,18 @@ impl UserDecryptSignaturePreChecker {
             }
         }
 
-        Err(SigPreCheckError::HostCallFailed(last_transport_err))
+        match last_retryable {
+            // Survived every attempt: no longer plausibly transient, so answer as a
+            // rejection rather than a server error.
+            Some(e @ Erc1271Error::EmptyRevert(_)) => Err(SigPreCheckError::Invalid {
+                signer: user_address,
+                reason: e.to_string(),
+            }),
+            Some(e) => Err(SigPreCheckError::HostCallFailed(e.to_string())),
+            None => Err(SigPreCheckError::HostCallFailed(
+                "signature pre-check exhausted its attempts without a result".to_string(),
+            )),
+        }
     }
 }
 
@@ -204,6 +217,14 @@ mod tests {
         U256::from_be_bytes(bytes)
     }
 
+    /// A node's reasonless-revert response: "execution reverted" with empty `data`.
+    fn empty_revert() -> alloy::rpc::json_rpc::ErrorPayload {
+        alloy::rpc::json_rpc::ErrorPayload::internal_error_with_message_and_obj(
+            std::borrow::Cow::Borrowed("execution reverted"),
+            serde_json::value::RawValue::from_string("\"0x\"".to_string()).unwrap(),
+        )
+    }
+
     fn checker(asserter: Asserter) -> UserDecryptSignaturePreChecker {
         let mut providers = HashMap::new();
         providers.insert(
@@ -215,7 +236,7 @@ mod tests {
         UserDecryptSignaturePreChecker {
             providers,
             decryption_contract: Address::from([0xCA; 20]),
-            erc1271_gas_limit: 100_000,
+            erc1271_gas_limit: 250_000,
             retry: RetrySettings {
                 max_attempts: 3,
                 retry_interval_ms: 0,
@@ -255,6 +276,36 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SigPreCheckError::HostCallFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn intermittent_empty_revert_is_retried() {
+        let asserter = Asserter::new();
+        // Attempt 1 reverts with no reason; attempt 2 succeeds.
+        asserter.push_failure(empty_revert());
+        let mut returndata = [0u8; 32];
+        returndata[..4].copy_from_slice(&[0x16, 0x26, 0xba, 0x7e]);
+        asserter.push_success(&returndata);
+
+        checker(asserter)
+            .verify(&unified_request(Bytes::from(vec![0x11; 65])))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn persistent_empty_revert_is_invalid_not_server_error() {
+        let asserter = Asserter::new();
+        // Three attempts, all reasonless reverts: no longer plausibly transient.
+        for _ in 0..3 {
+            asserter.push_failure(empty_revert());
+        }
+
+        let err = checker(asserter)
+            .verify(&unified_request(Bytes::from(vec![0x11; 65])))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SigPreCheckError::Invalid { .. }), "{err:?}");
     }
 
     #[tokio::test]

--- a/relayer/tests/relayer-test-config.yaml
+++ b/relayer/tests/relayer-test-config.yaml
@@ -21,7 +21,7 @@ keyurl:
   poll_interval_ms: 2000
 
 user_decrypt_signature_check:
-  erc1271_gas_limit: 100000
+  erc1271_gas_limit: 250000
 
 gateway:
   blockchain_rpc:

--- a/sdk/js-sdk/src/core/utils-p/decrypt/verifyErc1271UserDecrypt-p.test.ts
+++ b/sdk/js-sdk/src/core/utils-p/decrypt/verifyErc1271UserDecrypt-p.test.ts
@@ -184,6 +184,24 @@ describe('verifyErc1271UserDecrypt', () => {
     expect(data).toContain(remove0x(SIG_130));
   });
 
+  it('caps the ERC-1271 call at the advertised gas limit', async () => {
+    const call = queuedCall({ success: true, data: RETURN_MAGIC });
+    const { context } = makeContext({ call });
+
+    await expect(
+      verifyErc1271UserDecrypt(context, { userAddress: WALLET, eip712: makeEip712(), signature: SIG_65 }),
+    ).resolves.toBeUndefined();
+
+    // A literal, not ERC1271_GAS_LIMIT: the cap is shared with the relayer and the KMS
+    // connector, so moving it has to be a deliberate edit here too.
+    const mockCalls = (call as unknown as { mock: { calls: [unknown, { gas: bigint }][] } }).mock.calls;
+    const callArgs = mockCalls[0];
+    if (callArgs === undefined) {
+      throw new Error('expected the mocked eth_call to have been invoked');
+    }
+    expect(callArgs[1].gas).toBe(250_000n);
+  });
+
   it('accepts the empty approveHash signature when the wallet returns magic', async () => {
     const { context } = makeContext({ call: queuedCall({ success: true, data: RETURN_MAGIC }) });
 

--- a/sdk/js-sdk/src/core/utils-p/decrypt/verifyErc1271UserDecrypt-p.ts
+++ b/sdk/js-sdk/src/core/utils-p/decrypt/verifyErc1271UserDecrypt-p.ts
@@ -21,10 +21,11 @@ export const ERC1271_MAGIC_VALUE = '0x1626ba7e' as const;
 
 /**
  * Gas cap for the `isValidSignature` STATICCALL. Matches the relayer / KMS
- * default (`erc1271_gas_limit = 100000`) so all three layers bound the wallet's
- * verification the same way.
+ * default (`erc1271_gas_limit = 250000`) so all three layers bound the wallet's
+ * verification identically. A nested Safe (a Safe owning a Safe) costs ~91k
+ * gas; the rest is headroom for deeper nesting.
  */
-export const ERC1271_GAS_LIMIT = 100_000n;
+export const ERC1271_GAS_LIMIT = 250_000n;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/shared/user-decryption-signature/src/lib.rs
+++ b/shared/user-decryption-signature/src/lib.rs
@@ -62,6 +62,8 @@ pub enum Erc1271Error {
         "ERC-1271 isValidSignature reverted or returned malformed data for userAddress {0}: {1}"
     )]
     Rejected(Address, String),
+    #[error("ERC-1271 isValidSignature reverted with no reason for userAddress {0}")]
+    EmptyRevert(Address),
     #[error("RPC transport error during ERC-1271 verification: {0}")]
     Transport(String),
 }
@@ -115,7 +117,8 @@ fn try_ecrecover(digest: &B256, signature: &[u8]) -> Option<Address> {
 ///   outcome, slightly inaccurate error message; not worth a second RPC to disambiguate.
 /// - returndata length 1..32 → `Rejected` (non-compliant ABI return);
 /// - leading bytes don't match magic → `WrongMagic`;
-/// - `isValidSignature` call reverted → `Rejected`;
+/// - `isValidSignature` reverted with a reason → `Rejected`;
+/// - `isValidSignature` reverted with no reason → `EmptyRevert` (ambiguous, retryable);
 /// - any other RPC-layer error → `Transport`.
 async fn check_erc1271_signature<P: Provider>(
     provider: &P,
@@ -136,11 +139,18 @@ async fn check_erc1271_signature<P: Provider>(
     let returndata = provider.call(tx).await.map_err(|err| match err {
         RpcError::ErrorResp(e) => {
             if let Some(revert_data) = e.as_revert_data() {
-                // A revert is interpreted as an invalid signature
-                Erc1271Error::Rejected(
-                    addr,
-                    format!("isValidSignature call reverted: {revert_data}"),
-                )
+                // Empty `data` still counts as revert data to `as_revert_data`, but says
+                // nothing about why: an under-gassed call, a nested call into an address with
+                // no code, and a wallet reverting silently all look like this. Only a reason
+                // makes the rejection deterministic.
+                if revert_data.is_empty() {
+                    Erc1271Error::EmptyRevert(addr)
+                } else {
+                    Erc1271Error::Rejected(
+                        addr,
+                        format!("isValidSignature call reverted: {revert_data}"),
+                    )
+                }
             } else {
                 Erc1271Error::Transport(e.to_string())
             }
@@ -275,7 +285,7 @@ mod tests {
         let gateway = Address::from([0xCA; 20]);
         let (signer, _, digest, sig) = signed_payload(gateway);
 
-        verify_signature(&provider, signer.address(), digest, &sig, 100_000)
+        verify_signature(&provider, signer.address(), digest, &sig, TEST_GAS)
             .await
             .unwrap();
 
@@ -297,7 +307,7 @@ mod tests {
 
         asserter.push_success(&Bytes::default());
 
-        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+        let err = verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap_err();
         assert!(matches!(err, Erc1271Error::EoaMismatchNoCode(_)));
@@ -312,7 +322,7 @@ mod tests {
 
         asserter.push_success(&Bytes::default());
 
-        let err = verify_signature(&provider, claimed, digest, &[], 100_000)
+        let err = verify_signature(&provider, claimed, digest, &[], TEST_GAS)
             .await
             .unwrap_err();
         assert!(matches!(err, Erc1271Error::EmptySigOnEoa(_)));
@@ -331,7 +341,7 @@ mod tests {
         returndata[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
         asserter.push_success(&returndata);
 
-        verify_signature(&provider, claimed, digest, &sig, 100_000)
+        verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap();
     }
@@ -347,11 +357,14 @@ mod tests {
         // 32 bytes of zeros — wrong magic
         asserter.push_success(&[0u8; 32]);
 
-        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+        let err = verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap_err();
         assert!(matches!(err, Erc1271Error::WrongMagic(..)));
     }
+
+    /// Gas cap passed to the verifier, matching the shipped default.
+    const TEST_GAS: u64 = 250_000;
 
     /// Build a JSON-RPC error payload that mimics what an Ethereum node sends when the call
     /// reverts: a message containing "revert" plus a `data` field whose string value parses
@@ -373,10 +386,28 @@ mod tests {
 
         asserter.push_failure(revert_payload("0xdeadbeef"));
 
-        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+        let err = verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap_err();
         assert!(matches!(err, Erc1271Error::Rejected(_, _)));
+    }
+
+    #[tokio::test]
+    async fn erc1271_empty_revert_is_not_a_definitive_rejection() {
+        // `data: "0x"` is what a node returns for an under-gassed call. `as_revert_data`
+        // accepts it, so only the emptiness check keeps it out of `Rejected`.
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0x11_u8; 65];
+
+        asserter.push_failure(revert_payload("0x"));
+
+        let err = verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::EmptyRevert(_)), "got {err:?}");
     }
 
     #[tokio::test]
@@ -391,7 +422,7 @@ mod tests {
 
         asserter.push_failure_msg("rate limit exceeded");
 
-        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+        let err = verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap_err();
         assert!(matches!(err, Erc1271Error::Transport(_)));
@@ -408,7 +439,7 @@ mod tests {
         // Only 4 bytes returned — a non-compliant fallback function
         asserter.push_success(&ERC1271_MAGIC_VALUE);
 
-        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+        let err = verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap_err();
         assert!(matches!(err, Erc1271Error::Rejected(_, _)));
@@ -426,7 +457,7 @@ mod tests {
         returndata[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
         asserter.push_success(&returndata);
 
-        verify_signature(&provider, claimed, digest, &[], 100_000)
+        verify_signature(&provider, claimed, digest, &[], TEST_GAS)
             .await
             .unwrap();
     }
@@ -554,7 +585,7 @@ mod tests {
         returndata[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
         asserter.push_success(&returndata);
 
-        verify_signature(&provider, claimed, digest, &sig, 100_000)
+        verify_signature(&provider, claimed, digest, &sig, TEST_GAS)
             .await
             .unwrap();
     }

--- a/test-suite/e2e/test/erc1271UserDecryption/erc1271UserDecryption.ts
+++ b/test-suite/e2e/test/erc1271UserDecryption/erc1271UserDecryption.ts
@@ -17,6 +17,7 @@ import {
   chainIdFromHandle,
   computeUnifiedDigest,
   concatSignatureParts,
+  describeUnifiedFailure,
   directHandle,
   isSignatureRejection,
   pollJob,
@@ -27,8 +28,10 @@ import {
 import { Signers, getSigners, initSigners } from '../signers';
 import { FhevmInstances } from '../types';
 import {
+  ERC1271_GAS_LIMIT,
   SafeAccount,
   approveSafeHash,
+  assertErc1271ValidOnChain,
   buildSafeMultisigSignature,
   buildSafeNestedMultisigSignature,
   collectSafeOwnerParts,
@@ -63,6 +66,14 @@ const lazy = <T>(create: () => Promise<T>): (() => Promise<T>) => {
   let pending: Promise<T> | undefined;
   return () => (pending ??= create());
 };
+
+/**
+ * Failure hint for a positive whose signature the host chain already accepted,
+ * which narrows a `400` to the relayer's own gas cap or its view of the chain.
+ */
+const relayerCapHint = (gasNeeded: bigint): string =>
+  `(host chain accepts this signature: the ERC-1271 check costs ${gasNeeded} gas under the ${ERC1271_GAS_LIMIT} ` +
+  "cap asserted here, so a 400 points at the relayer's cap or its view of the chain)";
 
 /**
  * ERC-1271 support for smart-account signature verification.
@@ -235,8 +246,8 @@ describe('ERC-1271 user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     // Decrypt the same handle through the public SDK and assert the known plaintext.
     const clear = await instances.alice.userDecryptSingleHandle({
       handle,
@@ -267,8 +278,8 @@ describe('ERC-1271 user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt smart account (approveHash empty signature) succeeds', async function () {
@@ -287,7 +298,7 @@ describe('ERC-1271 user decryption', function () {
     await (await approveWallet.connect(signers.bob).approveHash(digest)).wait();
 
     const { post } = await submitUnifiedRequest(cfg, req, { kind: 'empty' });
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
     expect(post.jobId, JSON.stringify(post.raw)).to.be.a('string');
     const poll = await pollJob(cfg, post.jobId!, { timeoutMs: POSITIVE_TIMEOUT_MS });
     expect(poll.status, JSON.stringify(poll.raw)).to.equal('succeeded');
@@ -481,8 +492,8 @@ describe('ERC-1271 user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt Safe 1-of-1 single owner signature succeeds', async function () {
@@ -501,8 +512,8 @@ describe('ERC-1271 user decryption', function () {
       { kind: 'raw', signature },
       { waitForTerminal: true, timeoutMs: POSITIVE_TIMEOUT_MS },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig 3-of-3 concatenated owner signatures succeed', async function () {
@@ -520,8 +531,8 @@ describe('ERC-1271 user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig rejects a blob below threshold (1 of 3 parts)', async function () {
@@ -595,8 +606,8 @@ describe('ERC-1271 user decryption', function () {
       { kind: 'raw', signature },
       { waitForTerminal: true, timeoutMs: POSITIVE_TIMEOUT_MS },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig accepts a mixed blob (ECDSA part + pre-approved-hash part)', async function () {
@@ -617,8 +628,8 @@ describe('ERC-1271 user decryption', function () {
       { kind: 'raw', signature },
       { waitForTerminal: true, timeoutMs: POSITIVE_TIMEOUT_MS },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig rejects a pre-approved-hash part that was never approved', async function () {
@@ -654,8 +665,8 @@ describe('ERC-1271 user decryption', function () {
       { kind: 'raw', signature },
       { waitForTerminal: true, timeoutMs: POSITIVE_TIMEOUT_MS },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig accepts a v=0 contract-signature part (nested Safe owner)', async function () {
@@ -665,7 +676,7 @@ describe('ERC-1271 user decryption', function () {
     // The outer 2-of-3's approvals: a v=0 part from the inner 1-of-1 Safe
     // (dave signs the inner SafeMessage wrap of the outer preimage) + bob's
     // plain ECDSA part. 227 bytes: 130 static + 32-byte length + 65 inner.
-    // Measured ~83k gas incl. intrinsic vs the 100k erc1271_gas_limit.
+    // ~83k gas incl. intrinsic on canonical Safe v1.4.1.
     const signature = await buildSafeNestedMultisigSignature(
       (await nestedOuter1of1()).safe,
       digest,
@@ -673,14 +684,20 @@ describe('ERC-1271 user decryption', function () {
       [signers.bob],
     );
     expect(signature.length).to.equal(2 + 227 * 2);
+    const gasNeeded = await assertErc1271ValidOnChain(
+      ethers.provider,
+      (await nestedOuter1of1()).safe.address,
+      digest,
+      signature,
+    );
     const { post, poll } = await requestUnifiedUserDecrypt(
       cfg,
       req,
       { kind: 'raw', signature },
       { waitForTerminal: true, timeoutMs: POSITIVE_TIMEOUT_MS },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, `${describeUnifiedFailure(post)} ${relayerCapHint(gasNeeded)}`).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig accepts a v=0 part from a nested 2-of-3 Safe owner', async function () {
@@ -688,16 +705,14 @@ describe('ERC-1271 user decryption', function () {
     const req = await freshMultisigRequest(nestedOuter2of3);
     const digest = computeUnifiedDigest(cfg, req);
     // Same shape with a multisig INNER Safe (bob+dave of a 2-of-3): 292 bytes
-    // = 130 static + 32-byte length + 130 inner. Measured ~91k gas incl.
-    // intrinsic — only ~9% under the default 100k erc1271_gas_limit, so this
-    // positive doubles as a gas-headroom canary. Exceeding the cap does NOT
-    // read as an invalid signature: only an RPC error carrying revert data
-    // becomes `Rejected` (shared/user-decryption-signature/src/lib.rs:136-149)
-    // and out-of-gas carries none (anvil answers `EVM error OutOfGas`, no
-    // `data`), so it lands in `Transport` — the relayer retries and then fails
-    // the request with a 500 without ever queuing it
-    // (relayer/src/host/signature_prechecker.rs:130-157), while the connector
-    // treats the same class as recoverable and retries until it gives up.
+    // = 130 static + 32-byte length + 130 inner. ~91k gas incl. intrinsic —
+    // the most expensive shape in this suite, so the first positive to break
+    // if `erc1271_gas_limit` is set too low.
+    //
+    // A `400` here is ambiguous: an under-gassed call reverts with empty data,
+    // which `verify_signature` reports exactly like a forged blob, a genuine
+    // rejection being told apart only by carrying a revert reason. The
+    // cross-check below prices the call on-chain so the failure says which.
     const signature = await buildSafeNestedMultisigSignature(
       (await nestedOuter2of3()).safe,
       digest,
@@ -705,14 +720,20 @@ describe('ERC-1271 user decryption', function () {
       [signers.bob],
     );
     expect(signature.length).to.equal(2 + 292 * 2);
+    const gasNeeded = await assertErc1271ValidOnChain(
+      ethers.provider,
+      (await nestedOuter2of3()).safe.address,
+      digest,
+      signature,
+    );
     const { post, poll } = await requestUnifiedUserDecrypt(
       cfg,
       req,
       { kind: 'raw', signature },
       { waitForTerminal: true, timeoutMs: POSITIVE_TIMEOUT_MS },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, `${describeUnifiedFailure(post)} ${relayerCapHint(gasNeeded)}`).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
   });
 
   it('test erc1271 user decrypt multisig rejects a v=0 part whose inner signature is from a non-owner', async function () {

--- a/test-suite/e2e/test/erc1271UserDecryption/safe.ts
+++ b/test-suite/e2e/test/erc1271UserDecryption/safe.ts
@@ -20,11 +20,10 @@
 //     returning a non-magic value — an equally definitive rejection for the
 //     relayer, the KMS Connector, and the js-sdk;
 //   - answers through a proxy -> fallback-handler double round trip. Measured
-//     on the canonical bytecode (incl. intrinsic, vs the 100_000
+//     on the canonical bytecode (incl. intrinsic, against the
 //     `erc1271_gas_limit` all three verifying layers apply): worst flat shape
 //     (3-of-3 ECDSA) ~67k; nested v=0 contract-signature shapes ~83k (inner
-//     1-of-1) and ~91k (inner 2-of-3) — the latter has only ~9% headroom, so
-//     deeper nesting or higher inner thresholds would exceed the default cap.
+//     1-of-1) and ~91k (inner 2-of-3).
 import SafeArtifact from '@safe-global/safe-contracts/build/artifacts/contracts/Safe.sol/Safe.json';
 import CompatibilityFallbackHandlerArtifact from '@safe-global/safe-contracts/build/artifacts/contracts/handler/CompatibilityFallbackHandler.sol/CompatibilityFallbackHandler.json';
 import SafeProxyFactoryArtifact from '@safe-global/safe-contracts/build/artifacts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json';
@@ -82,6 +81,16 @@ const CANONICAL_SAFE_V1_4_1 = {
   handler: '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99',
   factory: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
 } as const;
+
+/** ERC-1271 magic value of `isValidSignature(bytes32,bytes)`. */
+const ERC1271_MAGIC_VALUE = '0x1626ba7e';
+
+/**
+ * Gas cap every verifying layer applies to the `isValidSignature` STATICCALL
+ * (relayer `erc1271_gas_limit`, KMS connector, js-sdk — kept equal). Override
+ * via `ERC1271_GAS_LIMIT` to match an environment configured differently.
+ */
+export const ERC1271_GAS_LIMIT = BigInt(process.env.ERC1271_GAS_LIMIT ?? 250_000);
 
 /** A canonical-code probe is one `eth_getCode`; retry once to ride out a rate-limit blip. */
 const PROBE_ATTEMPTS = 2;
@@ -411,4 +420,47 @@ export async function buildSafeNestedMultisigSignature(
     ...(await collectSafeOwnerParts(outer, digest, eoaOwners)),
   ]);
   return concatSignatureParts(staticParts, dynamicTail);
+}
+
+/**
+ * Cross-check on the host chain that `signature` is ERC-1271-valid for
+ * `account` under `gasLimit` — the same STATICCALL the relayer's pre-check
+ * runs — and return the gas the call needs.
+ *
+ * An under-gassed call reverts with empty data, which the relayer reports as
+ * `400 {"field":"signature","issue":"Signature is invalid"}` — the same body a
+ * forged blob gets, since a genuine rejection is told apart only by carrying a
+ * revert reason. Pricing the call here separates a bad signature from a budget
+ * too small to run it.
+ */
+export async function assertErc1271ValidOnChain(
+  provider: Provider,
+  account: string,
+  digest: string,
+  signature: string,
+  gasLimit: bigint = ERC1271_GAS_LIMIT,
+): Promise<bigint> {
+  const data = new Contract(account, CompatibilityFallbackHandlerArtifact.abi, provider).interface.encodeFunctionData(
+    'isValidSignature(bytes32,bytes)',
+    [digest, signature],
+  );
+  const gasNeeded = await provider.estimateGas({ to: account, data }).catch((error: unknown) => {
+    throw new Error(
+      `could not price the ERC-1271 call for ${account} (a bad signature, or a host RPC that would not run it): ` +
+        (error instanceof Error ? error.message : String(error)),
+    );
+  });
+  if (gasNeeded > gasLimit) {
+    throw new Error(
+      `ERC-1271 verification for ${account} needs ${gasNeeded} gas but the cap is ${gasLimit} — ` +
+        'the relayer would reject this valid signature with 400 "Signature is invalid"',
+    );
+  }
+  const returned = await provider.call({ to: account, data, gasLimit });
+  if (!returned.startsWith(ERC1271_MAGIC_VALUE)) {
+    throw new Error(
+      `ERC-1271 isValidSignature returned ${returned.slice(0, 10)} for ${account}, expected ${ERC1271_MAGIC_VALUE}`,
+    );
+  }
+  return gasNeeded;
 }

--- a/test-suite/e2e/test/sdk/unified/unifiedUserDecrypt.ts
+++ b/test-suite/e2e/test/sdk/unified/unifiedUserDecrypt.ts
@@ -471,6 +471,46 @@ export function isSignatureRejection(post: PostResult): boolean {
 }
 
 /**
+ * Describe a failed unified request for an assertion message.
+ *
+ * The signature pre-check keeps its reason server-side — the body says only
+ * `{"field":"signature","issue":"Signature is invalid"}` whatever the cause —
+ * so the message carries the requestId that keys into the relayer log.
+ */
+export function describeUnifiedFailure(post: PostResult, poll?: PollResult): string {
+  const body = post.raw as {
+    requestId?: string;
+    request_id?: string;
+    error?: { label?: string; message?: string; details?: Array<{ field?: string; issue?: string }> };
+  };
+  const parts = [`POST ${post.httpStatus}`, `requestId=${body.requestId ?? body.request_id ?? '<none>'}`];
+  if (post.jobId) {
+    parts.push(`jobId=${post.jobId}`);
+  }
+  if (body.error?.label) {
+    parts.push(`label=${body.error.label}`);
+  }
+  if (body.error?.message) {
+    parts.push(`message=${body.error.message}`);
+  }
+  const details = (body.error?.details ?? []).map((d) => `${d.field}: ${d.issue}`).join('; ');
+  if (details) {
+    parts.push(`details=[${details}]`);
+  }
+  if (poll) {
+    parts.push(`job=${poll.status}`);
+    if (poll.errorLabel) {
+      parts.push(`jobError=${poll.errorLabel}`);
+    }
+  }
+  if (isSignatureRejection(post)) {
+    parts.push('(the signature pre-check keeps its reason in the relayer log, under this requestId)');
+  }
+  parts.push(`raw=${JSON.stringify(poll?.raw ?? post.raw)}`);
+  return parts.join(' ');
+}
+
+/**
  * Assert an async rejection surfaced by the RELAYER's per-job host-ACL check:
  * terminal `failed` with `error.label == "not_allowed_on_host_acl"`. Used for
  * negatives whose cause is a per-handle ownership/delegation ACL failure —

--- a/test-suite/e2e/test/sdk/unified/unifiedUserDecrypt.ts
+++ b/test-suite/e2e/test/sdk/unified/unifiedUserDecrypt.ts
@@ -512,14 +512,21 @@ export function expectStuckAtKms(poll: PollResult | undefined): void {
  * Assert an async rejection surfaced by the relayer's transaction simulation:
  * the Gateway reverts the request on-chain, so the job goes terminal `failed`
  * before any transaction is sent (and before the decryption fee is charged).
- * The message pattern pins the exact revert so the test cannot pass on an
- * unrelated simulation failure.
+ * The relayer forwards the RPC error's `message` and drops `data`, where a custom
+ * error's selector lives — anvil inlines it into `message`, geth-family nodes do
+ * not. So pin the selector only when the node exposed one; a wrong-reason revert
+ * still fails.
  */
-export function expectGatewayRevert(poll: PollResult | undefined, messagePattern: RegExp): void {
+export function expectGatewayRevert(poll: PollResult | undefined, selector: string): void {
   assertReachedTerminalState(poll);
   expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('failed');
   const message = ((poll?.raw as { error?: { message?: string } })?.error?.message ?? '') as string;
-  expect(message, JSON.stringify(poll?.raw)).to.match(messagePattern);
+  expect(message, JSON.stringify(poll?.raw)).to.match(/execution reverted/i);
+
+  const exposed = message.match(/0x[0-9a-fA-F]{8,}/)?.[0];
+  if (exposed !== undefined) {
+    expect(exposed.toLowerCase(), JSON.stringify(poll?.raw)).to.have.string(selector.toLowerCase());
+  }
 }
 
 /** Build a direct-access handle entry (`ownerAddress == userAddress`). */

--- a/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
+++ b/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
@@ -750,9 +750,8 @@ describe('Unified user decryption', function () {
         },
       );
       expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      // InvalidKmsContext(<unknownContextId>) — selector 0x77ddbe81. The id is
-      // random per run, so this cannot pass or fail because of leftover state.
-      expectGatewayRevert(poll, /0x77ddbe81/i);
+      // InvalidKmsContext.
+      expectGatewayRevert(poll, '0x77ddbe81');
     });
 
     it('test unified user decrypt rejects a malformed extraData version', async function () {

--- a/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
+++ b/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
@@ -16,6 +16,7 @@ import type { UnifiedConfig, UnifiedDecryptRequest } from '../sdk/unified/unifie
 import {
   backdatedStartTimestamp,
   delegatedHandle,
+  describeUnifiedFailure,
   directHandle,
   expectGatewayRevert,
   expectRelayerAclRejection,
@@ -158,8 +159,8 @@ describe('Unified user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     // Assert the ciphertext really decrypts to the known plaintext. NOTE the
     // route: this helper uses the SDK's LEGACY permit (relayer `/v2`), so it
     // proves the value, NOT that the unified envelope works through the SDK —
@@ -222,8 +223,8 @@ describe('Unified user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     const clear = await instances.alice.userDecryptSingleHandle({
       handle: handle,
       contractAddress: aliceContractAddress,
@@ -256,8 +257,8 @@ describe('Unified user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     const clear = await instances.alice.userDecryptSingleHandle({
       handle: handle,
       contractAddress: aliceContractAddress,
@@ -290,8 +291,8 @@ describe('Unified user decryption', function () {
         timeoutMs: POSITIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-    expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+    expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     const clear32 = await instances.bob.userDecryptSingleHandle({
       handle: handle32,
       contractAddress: bobContractAddress,
@@ -366,7 +367,7 @@ describe('Unified user decryption', function () {
     // Signature is valid, so the relayer accepts; the contract-allowance check
     // is enforced only by the KMS Connector, which rejects without responding —
     // the job stays queued.
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
     expectStuckAtKms(poll);
   });
 
@@ -390,7 +391,7 @@ describe('Unified user decryption', function () {
         timeoutMs: negativeWindowMs,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
     expectStuckAtKms(poll);
   });
 
@@ -417,7 +418,7 @@ describe('Unified user decryption', function () {
     // bob's signature is valid, so the POST is accepted; the per-job host-ACL
     // check then fails (isAllowed(handle, bob) == false) and the job terminates
     // as failed with not_allowed_on_host_acl.
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
     expectRelayerAclRejection(poll);
   });
 
@@ -445,7 +446,7 @@ describe('Unified user decryption', function () {
         timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
     expectRelayerAclRejection(poll);
   });
 
@@ -476,7 +477,7 @@ describe('Unified user decryption', function () {
         timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
       },
     );
-    expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+    expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
     expectRelayerAclRejection(poll);
   });
 
@@ -570,8 +571,8 @@ describe('Unified user decryption', function () {
           timeoutMs: POSITIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+      expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
       const clear = await instances.alice.userDecryptSingleHandle({
         handle: handle,
         contractAddress: aliceContractAddress,
@@ -605,8 +606,8 @@ describe('Unified user decryption', function () {
           timeoutMs: POSITIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+      expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
       const clear = await instances.alice.userDecryptSingleHandle({
         handle: handle,
         contractAddress: aliceContractAddress,
@@ -641,8 +642,8 @@ describe('Unified user decryption', function () {
           timeoutMs: POSITIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+      expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
       const clear = await instances.alice.userDecryptSingleHandle({
         handle: handle,
         contractAddress: aliceContractAddress,
@@ -676,7 +677,7 @@ describe('Unified user decryption', function () {
           timeoutMs: negativeWindowMs,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
       expectStuckAtKms(poll);
     });
 
@@ -749,7 +750,7 @@ describe('Unified user decryption', function () {
           timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
       // InvalidKmsContext.
       expectGatewayRevert(poll, '0x77ddbe81');
     });
@@ -892,8 +893,8 @@ describe('Unified user decryption', function () {
           timeoutMs: POSITIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+      expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
       // Assert the known plaintexts of both legs through the public SDK: the
       // direct handle via the standard decrypt, the delegated handle via the
       // delegated decrypt (same pattern as the legacy delegated suite).
@@ -938,8 +939,8 @@ describe('Unified user decryption', function () {
           timeoutMs: POSITIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+      expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     });
 
     it('test unified user decrypt rejects a delegated handle with a fabricated contractAddress', async function () {
@@ -965,7 +966,7 @@ describe('Unified user decryption', function () {
           timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
       expectRelayerAclRejection(poll);
     });
 
@@ -996,7 +997,7 @@ describe('Unified user decryption', function () {
           timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
       expectRelayerAclRejection(poll);
     });
 
@@ -1038,7 +1039,7 @@ describe('Unified user decryption', function () {
           timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
       expectRelayerAclRejection(poll);
     });
 
@@ -1076,8 +1077,8 @@ describe('Unified user decryption', function () {
         waitForTerminal: true,
         timeoutMs: POSITIVE_TIMEOUT_MS,
       });
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
+      expect(poll?.status, describeUnifiedFailure(post, poll)).to.equal('succeeded');
     });
 
     it('test unified user decrypt revoking a contract delegate closes access for its current signer', async function () {
@@ -1113,7 +1114,7 @@ describe('Unified user decryption', function () {
         waitForTerminal: true,
         timeoutMs: negativeWindowMs,
       });
-      expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
+      expect(post.httpStatus, describeUnifiedFailure(post)).to.equal(202);
       expectRelayerAclRejection(poll);
     });
   });

--- a/test-suite/fhevm/templates/config/relayer.yaml
+++ b/test-suite/fhevm/templates/config/relayer.yaml
@@ -11,7 +11,11 @@ protocol_config:
     retry_interval_ms: 200
 
 user_decrypt_signature_check:
-  erc1271_gas_limit: 100000
+  # Gas cap for the ERC-1271 `isValidSignature` STATICCALL. A nested Safe (a Safe owning
+  # a Safe) costs ~91k gas; the rest is headroom for deeper nesting, and a call needing
+  # more than 100k is logged. Keep equal to the KMS connector default and the js-sdk
+  # ERC1271_GAS_LIMIT, which cap the same call.
+  erc1271_gas_limit: 250000
 
 gateway:
   blockchain_rpc:

--- a/test-suite/fhevm/templates/config/relayer.yaml
+++ b/test-suite/fhevm/templates/config/relayer.yaml
@@ -12,8 +12,8 @@ protocol_config:
 
 user_decrypt_signature_check:
   # Gas cap for the ERC-1271 `isValidSignature` STATICCALL. A nested Safe (a Safe owning
-  # a Safe) costs ~91k gas; the rest is headroom for deeper nesting, and a call needing
-  # more than 100k is logged. Keep equal to the KMS connector default and the js-sdk
+  # a Safe) costs ~91k gas; the rest is headroom for deeper nesting. Keep equal to the
+  # KMS connector default and the js-sdk
   # ERC1271_GAS_LIMIT, which cap the same call.
   erc1271_gas_limit: 250000
 


### PR DESCRIPTION
Backports two `release/0.14.x` commits to `main`:

- #3584 — assert the gateway revert by selector, not node error formatting
- #3804 — ERC-1271 e2e hardening: a reasonless `isValidSignature` revert is retried instead of rejected outright (`Erc1271Error::EmptyRevert`), the gas cap moves 100k → 250k across relayer, KMS connector and js-sdk, and the  nested-Safe positives cross-check the signature on-chain and report the  relayer requestId on failure.

Adaptations for main:
- `relayer/Cargo.lock` hunk dropped — main already ships the three advisory  fixes (crossbeam-epoch 0.9.20, h2 0.4.16, ruint 1.20.0).
- `error.rs` adapted to main's `ErrorCode` API; retry/recoverable semantics  unchanged from what was reviewed on 0.14.x.
- Main-only tests preserved; `expectRelayerAclRejection` pattern arguments  dropped since main's helper doesn't evaluate them.